### PR TITLE
Release 0.1.5

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -1,7 +1,11 @@
 = Changes
 
-This document describes the relevant changes between releases of the _Unified
-Hybrid Cloud_ API SDK.
+This document describes the relevant changes between releases of the UHC API
+SDK.
+
+== 0.1.5 Apr 17 2019
+
+- Changed package path to `github.com/openshift-online/uhc-sdk-go`.
 
 == 0.1.4 Apr 3 2019
 

--- a/pkg/client/version.go
+++ b/pkg/client/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package client
 
-const Version = "0.1.4"
+const Version = "0.1.5"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Changed package path to `github.com/openshift-online/uhc-sdk-go`.