### PR TITLE
Use typed interface in `README.adoc`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -23,47 +23,76 @@ import (
         "os"
 
         "github.com/openshift-online/uhc-sdk-go/pkg/client"
+	"github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1"
 )
 
 func main() {
-        // Create the connection, and remember to close it:
-        connection, err := client.NewConnectionBuilder().
-                Tokens("eyJ...").
-                Build()
-        if err != nil {
-                fmt.Fprintf(os.Stderr, "Can't build connection: %v\n", err)
-                os.Exit(1)
-        }
-        defer connection.Close()
+	// Create a logger that has the debug level enabled:
+	logger, err := client.NewGoLoggerBuilder().
+		Debug(true).
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build logger: %v\n", err)
+		os.Exit(1)
+	}
 
-        // Send a request to create a cluster:
-        response, err := connection.Post().
-                Path("/api/clusters_mgmt/v1/clusters").
-                String(`{
-                        "name": "mycluster",
-                        "flavour": {
-                                "id": "4"
-                        },
-                        "region": {
-                                "id": "us-east-1",
-                        },
-                        "dns": {
-                                "base_domain": "mydomain.com"
-                        },
-                        "aws": {
-                                "access_key_id": "...",
-                                "secret_access_key": "..."
-                        }
-                }`).
-                Send()
-        if err != nil {
-                fmt.Fprintf(os.Stderr, "Can't create cluster: %s\n", err)
-                os.Exit(1)
-        }
+	// Create the connection, and remember to close it:
+	token := os.Getenv("UHC_TOKEN")
+	connection, err := client.NewConnectionBuilder().
+		Logger(logger).
+		Tokens(token).
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build connection: %v\n", err)
+		os.Exit(1)
+	}
+	defer connection.Close()
 
-        // Print the result:
-        fmt.Printf("%d\n", response.Status())
-        fmt.Printf("%s\n", response.String())
+	// Get the client for the resource that manages the collection of clusters:
+	collection := connection.ClustersMgmt().V1().Clusters()
+
+	// Prepare the description of the cluster to create:
+	cluster, err := v1.NewCluster().
+		Name("mycluster").
+		Flavour(
+			v1.NewFlavour().
+				ID("4"),
+		).
+		Region(
+			v1.NewCloudRegion().
+				ID("us-east-1"),
+		).
+		DNS(
+			v1.NewDNS().
+				BaseDomain("example.com"),
+		).
+		AWS(
+			v1.NewAWS().
+				AccessKeyID("...").
+				SecretAccessKey("..."),
+		).
+		Version(
+			v1.NewVersion().
+				ID("openshift-v4.0-beta4"),
+		).
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't create cluster description: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Send a request to create the cluster:
+	response, err := collection.Add().
+		Body(cluster).
+		Send()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't create cluster: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Print the result:
+	cluster = response.Body()
+	fmt.Printf("%s - %s\n", cluster.ID(), cluster.Name())
 }
 ----
 
@@ -71,4 +100,5 @@ There are more examples in the link:examples[examples] directory.
 
 == CLI
 
-See also the command-line tool https://github.com/openshift-online/uhc-cli built on top of this SDK.
+See also the command-line tool https://github.com/openshift-online/uhc-cli built
+on top of this SDK.

--- a/examples/create_cluster.go
+++ b/examples/create_cluster.go
@@ -60,10 +60,18 @@ func main() {
 			v1.NewCloudRegion().
 				ID("us-east-1"),
 		).
+		DNS(
+			v1.NewDNS().
+				BaseDomain("example.com"),
+		).
 		AWS(
 			v1.NewAWS().
 				AccessKeyID("...").
 				SecretAccessKey("..."),
+		).
+		Version(
+			v1.NewVersion().
+				ID("openshift-v4.0-beta4"),
 		).
 		Build()
 	if err != nil {


### PR DESCRIPTION
This patch changes the examples in the `README.adoc` file so that they
use the typed interface.