### PR TITLE
Fix unmarshalling of list of class instances

### DIFF
--- a/pkg/client/accountsmgmt/v1/access_token_list_reader.go
+++ b/pkg/client/accountsmgmt/v1/access_token_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalAccessTokenList(source interface{}) (list *AccessTokenList, err er
 
 // wrap is the method used internally to convert a list of values of the
 // 'access_token' value to a JSON document.
-func (o *AccessTokenList) wrap() (data accessTokenListData, err error) {
-	if o == nil {
+func (l *AccessTokenList) wrap() (data accessTokenListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(accessTokenListData, len(o.items))
-	for i, item := range o.items {
+	data = make(accessTokenListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/accountsmgmt/v1/account_list_reader.go
+++ b/pkg/client/accountsmgmt/v1/account_list_reader.go
@@ -20,6 +20,8 @@ limitations under the License.
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/accountsmgmt/v1
 
 import (
+	"fmt"
+
 	"github.com/openshift-online/uhc-sdk-go/pkg/client/helpers"
 )
 
@@ -46,12 +48,12 @@ func UnmarshalAccountList(source interface{}) (list *AccountList, err error) {
 
 // wrap is the method used internally to convert a list of values of the
 // 'account' value to a JSON document.
-func (o *AccountList) wrap() (data accountListData, err error) {
-	if o == nil {
+func (l *AccountList) wrap() (data accountListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(accountListData, len(o.items))
-	for i, item := range o.items {
+	data = make(accountListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return
@@ -75,5 +77,73 @@ func (d accountListData) unwrap() (list *AccountList, err error) {
 	}
 	list = new(AccountList)
 	list.items = items
+	return
+}
+
+// accountListLinkData is type used internally to marshal and unmarshal links
+// to lists of objects of type 'account'.
+type accountListLinkData struct {
+	Kind  *string        "json:\"kind,omitempty\""
+	HREF  *string        "json:\"href,omitempty\""
+	Items []*accountData "json:\"items,omitempty\""
+}
+
+// wrapLink is the method used internally to convert a list of values of the
+// 'account' value to a link.
+func (l *AccountList) wrapLink() (data *accountListLinkData, err error) {
+	if l == nil {
+		return
+	}
+	items := make([]*accountData, len(l.items))
+	for i, item := range l.items {
+		items[i], err = item.wrap()
+		if err != nil {
+			return
+		}
+	}
+	data = new(accountListLinkData)
+	data.Items = items
+	data.HREF = l.href
+	data.Kind = new(string)
+	if l.link {
+		*data.Kind = AccountListLinkKind
+	} else {
+		*data.Kind = AccountListKind
+	}
+	return
+}
+
+// unwrapLink is the function used internally to convert a JSON link to a list
+// of values of the 'account' type to a list.
+func (d *accountListLinkData) unwrapLink() (list *AccountList, err error) {
+	if d == nil {
+		return
+	}
+	items := make([]*Account, len(d.Items))
+	for i, item := range d.Items {
+		items[i], err = item.unwrap()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AccountList)
+	list.items = items
+	list.href = d.HREF
+	if d.Kind != nil {
+		switch *d.Kind {
+		case AccountListKind:
+			list.link = false
+		case AccountListLinkKind:
+			list.link = true
+		default:
+			err = fmt.Errorf(
+				"expected kind '%s' or '%s' but got '%s'",
+				AccountListKind,
+				AccountListLinkKind,
+				*d.Kind,
+			)
+			return
+		}
+	}
 	return
 }

--- a/pkg/client/accountsmgmt/v1/account_type.go
+++ b/pkg/client/accountsmgmt/v1/account_type.go
@@ -236,9 +236,57 @@ func (o *Account) GetOrganization() (value *Organization, ok bool) {
 	return
 }
 
+// AccountListKind is the name of the type used to represent list of
+// objects of type 'account'.
+const AccountListKind = "AccountList"
+
+// AccountListLinkKind is the name of the type used to represent links
+// to list of objects of type 'account'.
+const AccountListLinkKind = "AccountListLink"
+
+// AccountNilKind is the name of the type used to nil lists of
+// objects of type 'account'.
+const AccountListNilKind = "AccountListNil"
+
 // AccountList is a list of values of the 'account' type.
 type AccountList struct {
+	href  *string
+	link  bool
 	items []*Account
+}
+
+// Kind returns the name of the type of the object.
+func (l *AccountList) Kind() string {
+	if l == nil {
+		return AccountListNilKind
+	}
+	if l.link {
+		return AccountListLinkKind
+	}
+	return AccountListKind
+}
+
+// Link returns true iif this is a link.
+func (l *AccountList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *AccountList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *AccountList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/accountsmgmt/v1/cluster_authorization_request_list_reader.go
+++ b/pkg/client/accountsmgmt/v1/cluster_authorization_request_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalClusterAuthorizationRequestList(source interface{}) (list *Cluster
 
 // wrap is the method used internally to convert a list of values of the
 // 'cluster_authorization_request' value to a JSON document.
-func (o *ClusterAuthorizationRequestList) wrap() (data clusterAuthorizationRequestListData, err error) {
-	if o == nil {
+func (l *ClusterAuthorizationRequestList) wrap() (data clusterAuthorizationRequestListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(clusterAuthorizationRequestListData, len(o.items))
-	for i, item := range o.items {
+	data = make(clusterAuthorizationRequestListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/accountsmgmt/v1/cluster_authorization_request_reader.go
+++ b/pkg/client/accountsmgmt/v1/cluster_authorization_request_reader.go
@@ -62,6 +62,10 @@ func (o *ClusterAuthorizationRequest) wrap() (data *clusterAuthorizationRequestD
 	data.Reserve = o.reserve
 	data.BYOC = o.byoc
 	data.AvailabilityZone = o.availabilityZone
+	data.Resources, err = o.resources.wrap()
+	if err != nil {
+		return
+	}
 	return
 }
 
@@ -94,5 +98,9 @@ func (d *clusterAuthorizationRequestData) unwrap() (object *ClusterAuthorization
 	object.reserve = d.Reserve
 	object.byoc = d.BYOC
 	object.availabilityZone = d.AvailabilityZone
+	object.resources, err = d.Resources.unwrap()
+	if err != nil {
+		return
+	}
 	return
 }

--- a/pkg/client/accountsmgmt/v1/cluster_authorization_response_list_reader.go
+++ b/pkg/client/accountsmgmt/v1/cluster_authorization_response_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalClusterAuthorizationResponseList(source interface{}) (list *Cluste
 
 // wrap is the method used internally to convert a list of values of the
 // 'cluster_authorization_response' value to a JSON document.
-func (o *ClusterAuthorizationResponseList) wrap() (data clusterAuthorizationResponseListData, err error) {
-	if o == nil {
+func (l *ClusterAuthorizationResponseList) wrap() (data clusterAuthorizationResponseListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(clusterAuthorizationResponseListData, len(o.items))
-	for i, item := range o.items {
+	data = make(clusterAuthorizationResponseListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/accountsmgmt/v1/cluster_authorization_response_reader.go
+++ b/pkg/client/accountsmgmt/v1/cluster_authorization_response_reader.go
@@ -53,6 +53,10 @@ func (o *ClusterAuthorizationResponse) wrap() (data *clusterAuthorizationRespons
 	}
 	data = new(clusterAuthorizationResponseData)
 	data.Allowed = o.allowed
+	data.ExcessResources, err = o.excessResources.wrap()
+	if err != nil {
+		return
+	}
 	data.Subscription, err = o.subscription.wrap()
 	if err != nil {
 		return
@@ -84,6 +88,10 @@ func (d *clusterAuthorizationResponseData) unwrap() (object *ClusterAuthorizatio
 	}
 	object = new(ClusterAuthorizationResponse)
 	object.allowed = d.Allowed
+	object.excessResources, err = d.ExcessResources.unwrap()
+	if err != nil {
+		return
+	}
 	object.subscription, err = d.Subscription.unwrap()
 	if err != nil {
 		return

--- a/pkg/client/accountsmgmt/v1/cluster_registration_request_list_reader.go
+++ b/pkg/client/accountsmgmt/v1/cluster_registration_request_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalClusterRegistrationRequestList(source interface{}) (list *ClusterR
 
 // wrap is the method used internally to convert a list of values of the
 // 'cluster_registration_request' value to a JSON document.
-func (o *ClusterRegistrationRequestList) wrap() (data clusterRegistrationRequestListData, err error) {
-	if o == nil {
+func (l *ClusterRegistrationRequestList) wrap() (data clusterRegistrationRequestListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(clusterRegistrationRequestListData, len(o.items))
-	for i, item := range o.items {
+	data = make(clusterRegistrationRequestListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/accountsmgmt/v1/cluster_registration_response_list_reader.go
+++ b/pkg/client/accountsmgmt/v1/cluster_registration_response_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalClusterRegistrationResponseList(source interface{}) (list *Cluster
 
 // wrap is the method used internally to convert a list of values of the
 // 'cluster_registration_response' value to a JSON document.
-func (o *ClusterRegistrationResponseList) wrap() (data clusterRegistrationResponseListData, err error) {
-	if o == nil {
+func (l *ClusterRegistrationResponseList) wrap() (data clusterRegistrationResponseListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(clusterRegistrationResponseListData, len(o.items))
-	for i, item := range o.items {
+	data = make(clusterRegistrationResponseListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/accountsmgmt/v1/errors.go
+++ b/pkg/client/accountsmgmt/v1/errors.go
@@ -18,3 +18,5 @@ limitations under the License.
 // your changes will be lost when the file is generated again.
 
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/accountsmgmt/v1
+
+const ()

--- a/pkg/client/accountsmgmt/v1/organization_type.go
+++ b/pkg/client/accountsmgmt/v1/organization_type.go
@@ -116,9 +116,57 @@ func (o *Organization) GetName() (value string, ok bool) {
 	return
 }
 
+// OrganizationListKind is the name of the type used to represent list of
+// objects of type 'organization'.
+const OrganizationListKind = "OrganizationList"
+
+// OrganizationListLinkKind is the name of the type used to represent links
+// to list of objects of type 'organization'.
+const OrganizationListLinkKind = "OrganizationListLink"
+
+// OrganizationNilKind is the name of the type used to nil lists of
+// objects of type 'organization'.
+const OrganizationListNilKind = "OrganizationListNil"
+
 // OrganizationList is a list of values of the 'organization' type.
 type OrganizationList struct {
+	href  *string
+	link  bool
 	items []*Organization
+}
+
+// Kind returns the name of the type of the object.
+func (l *OrganizationList) Kind() string {
+	if l == nil {
+		return OrganizationListNilKind
+	}
+	if l.link {
+		return OrganizationListLinkKind
+	}
+	return OrganizationListKind
+}
+
+// Link returns true iif this is a link.
+func (l *OrganizationList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *OrganizationList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *OrganizationList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/accountsmgmt/v1/permission_type.go
+++ b/pkg/client/accountsmgmt/v1/permission_type.go
@@ -164,9 +164,57 @@ func (o *Permission) GetRoleID() (value string, ok bool) {
 	return
 }
 
+// PermissionListKind is the name of the type used to represent list of
+// objects of type 'permission'.
+const PermissionListKind = "PermissionList"
+
+// PermissionListLinkKind is the name of the type used to represent links
+// to list of objects of type 'permission'.
+const PermissionListLinkKind = "PermissionListLink"
+
+// PermissionNilKind is the name of the type used to nil lists of
+// objects of type 'permission'.
+const PermissionListNilKind = "PermissionListNil"
+
 // PermissionList is a list of values of the 'permission' type.
 type PermissionList struct {
+	href  *string
+	link  bool
 	items []*Permission
+}
+
+// Kind returns the name of the type of the object.
+func (l *PermissionList) Kind() string {
+	if l == nil {
+		return PermissionListNilKind
+	}
+	if l.link {
+		return PermissionListLinkKind
+	}
+	return PermissionListKind
+}
+
+// Link returns true iif this is a link.
+func (l *PermissionList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *PermissionList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *PermissionList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/accountsmgmt/v1/plan_type.go
+++ b/pkg/client/accountsmgmt/v1/plan_type.go
@@ -92,9 +92,57 @@ func (o *Plan) GetHREF() (value string, ok bool) {
 	return
 }
 
+// PlanListKind is the name of the type used to represent list of
+// objects of type 'plan'.
+const PlanListKind = "PlanList"
+
+// PlanListLinkKind is the name of the type used to represent links
+// to list of objects of type 'plan'.
+const PlanListLinkKind = "PlanListLink"
+
+// PlanNilKind is the name of the type used to nil lists of
+// objects of type 'plan'.
+const PlanListNilKind = "PlanListNil"
+
 // PlanList is a list of values of the 'plan' type.
 type PlanList struct {
+	href  *string
+	link  bool
 	items []*Plan
+}
+
+// Kind returns the name of the type of the object.
+func (l *PlanList) Kind() string {
+	if l == nil {
+		return PlanListNilKind
+	}
+	if l.link {
+		return PlanListLinkKind
+	}
+	return PlanListKind
+}
+
+// Link returns true iif this is a link.
+func (l *PlanList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *PlanList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *PlanList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/accountsmgmt/v1/registry_credential_list_reader.go
+++ b/pkg/client/accountsmgmt/v1/registry_credential_list_reader.go
@@ -20,6 +20,8 @@ limitations under the License.
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/accountsmgmt/v1
 
 import (
+	"fmt"
+
 	"github.com/openshift-online/uhc-sdk-go/pkg/client/helpers"
 )
 
@@ -46,12 +48,12 @@ func UnmarshalRegistryCredentialList(source interface{}) (list *RegistryCredenti
 
 // wrap is the method used internally to convert a list of values of the
 // 'registry_credential' value to a JSON document.
-func (o *RegistryCredentialList) wrap() (data registryCredentialListData, err error) {
-	if o == nil {
+func (l *RegistryCredentialList) wrap() (data registryCredentialListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(registryCredentialListData, len(o.items))
-	for i, item := range o.items {
+	data = make(registryCredentialListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return
@@ -75,5 +77,73 @@ func (d registryCredentialListData) unwrap() (list *RegistryCredentialList, err 
 	}
 	list = new(RegistryCredentialList)
 	list.items = items
+	return
+}
+
+// registryCredentialListLinkData is type used internally to marshal and unmarshal links
+// to lists of objects of type 'registry_credential'.
+type registryCredentialListLinkData struct {
+	Kind  *string                   "json:\"kind,omitempty\""
+	HREF  *string                   "json:\"href,omitempty\""
+	Items []*registryCredentialData "json:\"items,omitempty\""
+}
+
+// wrapLink is the method used internally to convert a list of values of the
+// 'registry_credential' value to a link.
+func (l *RegistryCredentialList) wrapLink() (data *registryCredentialListLinkData, err error) {
+	if l == nil {
+		return
+	}
+	items := make([]*registryCredentialData, len(l.items))
+	for i, item := range l.items {
+		items[i], err = item.wrap()
+		if err != nil {
+			return
+		}
+	}
+	data = new(registryCredentialListLinkData)
+	data.Items = items
+	data.HREF = l.href
+	data.Kind = new(string)
+	if l.link {
+		*data.Kind = RegistryCredentialListLinkKind
+	} else {
+		*data.Kind = RegistryCredentialListKind
+	}
+	return
+}
+
+// unwrapLink is the function used internally to convert a JSON link to a list
+// of values of the 'registry_credential' type to a list.
+func (d *registryCredentialListLinkData) unwrapLink() (list *RegistryCredentialList, err error) {
+	if d == nil {
+		return
+	}
+	items := make([]*RegistryCredential, len(d.Items))
+	for i, item := range d.Items {
+		items[i], err = item.unwrap()
+		if err != nil {
+			return
+		}
+	}
+	list = new(RegistryCredentialList)
+	list.items = items
+	list.href = d.HREF
+	if d.Kind != nil {
+		switch *d.Kind {
+		case RegistryCredentialListKind:
+			list.link = false
+		case RegistryCredentialListLinkKind:
+			list.link = true
+		default:
+			err = fmt.Errorf(
+				"expected kind '%s' or '%s' but got '%s'",
+				RegistryCredentialListKind,
+				RegistryCredentialListLinkKind,
+				*d.Kind,
+			)
+			return
+		}
+	}
 	return
 }

--- a/pkg/client/accountsmgmt/v1/registry_credential_type.go
+++ b/pkg/client/accountsmgmt/v1/registry_credential_type.go
@@ -188,9 +188,57 @@ func (o *RegistryCredential) GetAccount() (value *Account, ok bool) {
 	return
 }
 
+// RegistryCredentialListKind is the name of the type used to represent list of
+// objects of type 'registry_credential'.
+const RegistryCredentialListKind = "RegistryCredentialList"
+
+// RegistryCredentialListLinkKind is the name of the type used to represent links
+// to list of objects of type 'registry_credential'.
+const RegistryCredentialListLinkKind = "RegistryCredentialListLink"
+
+// RegistryCredentialNilKind is the name of the type used to nil lists of
+// objects of type 'registry_credential'.
+const RegistryCredentialListNilKind = "RegistryCredentialListNil"
+
 // RegistryCredentialList is a list of values of the 'registry_credential' type.
 type RegistryCredentialList struct {
+	href  *string
+	link  bool
 	items []*RegistryCredential
+}
+
+// Kind returns the name of the type of the object.
+func (l *RegistryCredentialList) Kind() string {
+	if l == nil {
+		return RegistryCredentialListNilKind
+	}
+	if l.link {
+		return RegistryCredentialListLinkKind
+	}
+	return RegistryCredentialListKind
+}
+
+// Link returns true iif this is a link.
+func (l *RegistryCredentialList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *RegistryCredentialList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *RegistryCredentialList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/accountsmgmt/v1/registry_list_reader.go
+++ b/pkg/client/accountsmgmt/v1/registry_list_reader.go
@@ -20,6 +20,8 @@ limitations under the License.
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/accountsmgmt/v1
 
 import (
+	"fmt"
+
 	"github.com/openshift-online/uhc-sdk-go/pkg/client/helpers"
 )
 
@@ -46,12 +48,12 @@ func UnmarshalRegistryList(source interface{}) (list *RegistryList, err error) {
 
 // wrap is the method used internally to convert a list of values of the
 // 'registry' value to a JSON document.
-func (o *RegistryList) wrap() (data registryListData, err error) {
-	if o == nil {
+func (l *RegistryList) wrap() (data registryListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(registryListData, len(o.items))
-	for i, item := range o.items {
+	data = make(registryListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return
@@ -75,5 +77,73 @@ func (d registryListData) unwrap() (list *RegistryList, err error) {
 	}
 	list = new(RegistryList)
 	list.items = items
+	return
+}
+
+// registryListLinkData is type used internally to marshal and unmarshal links
+// to lists of objects of type 'registry'.
+type registryListLinkData struct {
+	Kind  *string         "json:\"kind,omitempty\""
+	HREF  *string         "json:\"href,omitempty\""
+	Items []*registryData "json:\"items,omitempty\""
+}
+
+// wrapLink is the method used internally to convert a list of values of the
+// 'registry' value to a link.
+func (l *RegistryList) wrapLink() (data *registryListLinkData, err error) {
+	if l == nil {
+		return
+	}
+	items := make([]*registryData, len(l.items))
+	for i, item := range l.items {
+		items[i], err = item.wrap()
+		if err != nil {
+			return
+		}
+	}
+	data = new(registryListLinkData)
+	data.Items = items
+	data.HREF = l.href
+	data.Kind = new(string)
+	if l.link {
+		*data.Kind = RegistryListLinkKind
+	} else {
+		*data.Kind = RegistryListKind
+	}
+	return
+}
+
+// unwrapLink is the function used internally to convert a JSON link to a list
+// of values of the 'registry' type to a list.
+func (d *registryListLinkData) unwrapLink() (list *RegistryList, err error) {
+	if d == nil {
+		return
+	}
+	items := make([]*Registry, len(d.Items))
+	for i, item := range d.Items {
+		items[i], err = item.unwrap()
+		if err != nil {
+			return
+		}
+	}
+	list = new(RegistryList)
+	list.items = items
+	list.href = d.HREF
+	if d.Kind != nil {
+		switch *d.Kind {
+		case RegistryListKind:
+			list.link = false
+		case RegistryListLinkKind:
+			list.link = true
+		default:
+			err = fmt.Errorf(
+				"expected kind '%s' or '%s' but got '%s'",
+				RegistryListKind,
+				RegistryListLinkKind,
+				*d.Kind,
+			)
+			return
+		}
+	}
 	return
 }

--- a/pkg/client/accountsmgmt/v1/registry_type.go
+++ b/pkg/client/accountsmgmt/v1/registry_type.go
@@ -236,9 +236,57 @@ func (o *Registry) GetCloudAlias() (value bool, ok bool) {
 	return
 }
 
+// RegistryListKind is the name of the type used to represent list of
+// objects of type 'registry'.
+const RegistryListKind = "RegistryList"
+
+// RegistryListLinkKind is the name of the type used to represent links
+// to list of objects of type 'registry'.
+const RegistryListLinkKind = "RegistryListLink"
+
+// RegistryNilKind is the name of the type used to nil lists of
+// objects of type 'registry'.
+const RegistryListNilKind = "RegistryListNil"
+
 // RegistryList is a list of values of the 'registry' type.
 type RegistryList struct {
+	href  *string
+	link  bool
 	items []*Registry
+}
+
+// Kind returns the name of the type of the object.
+func (l *RegistryList) Kind() string {
+	if l == nil {
+		return RegistryListNilKind
+	}
+	if l.link {
+		return RegistryListLinkKind
+	}
+	return RegistryListKind
+}
+
+// Link returns true iif this is a link.
+func (l *RegistryList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *RegistryList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *RegistryList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/accountsmgmt/v1/reserved_resource_list_reader.go
+++ b/pkg/client/accountsmgmt/v1/reserved_resource_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalReservedResourceList(source interface{}) (list *ReservedResourceLi
 
 // wrap is the method used internally to convert a list of values of the
 // 'reserved_resource' value to a JSON document.
-func (o *ReservedResourceList) wrap() (data reservedResourceListData, err error) {
-	if o == nil {
+func (l *ReservedResourceList) wrap() (data reservedResourceListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(reservedResourceListData, len(o.items))
-	for i, item := range o.items {
+	data = make(reservedResourceListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/accountsmgmt/v1/resource_quota_list_reader.go
+++ b/pkg/client/accountsmgmt/v1/resource_quota_list_reader.go
@@ -20,6 +20,8 @@ limitations under the License.
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/accountsmgmt/v1
 
 import (
+	"fmt"
+
 	"github.com/openshift-online/uhc-sdk-go/pkg/client/helpers"
 )
 
@@ -46,12 +48,12 @@ func UnmarshalResourceQuotaList(source interface{}) (list *ResourceQuotaList, er
 
 // wrap is the method used internally to convert a list of values of the
 // 'resource_quota' value to a JSON document.
-func (o *ResourceQuotaList) wrap() (data resourceQuotaListData, err error) {
-	if o == nil {
+func (l *ResourceQuotaList) wrap() (data resourceQuotaListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(resourceQuotaListData, len(o.items))
-	for i, item := range o.items {
+	data = make(resourceQuotaListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return
@@ -75,5 +77,73 @@ func (d resourceQuotaListData) unwrap() (list *ResourceQuotaList, err error) {
 	}
 	list = new(ResourceQuotaList)
 	list.items = items
+	return
+}
+
+// resourceQuotaListLinkData is type used internally to marshal and unmarshal links
+// to lists of objects of type 'resource_quota'.
+type resourceQuotaListLinkData struct {
+	Kind  *string              "json:\"kind,omitempty\""
+	HREF  *string              "json:\"href,omitempty\""
+	Items []*resourceQuotaData "json:\"items,omitempty\""
+}
+
+// wrapLink is the method used internally to convert a list of values of the
+// 'resource_quota' value to a link.
+func (l *ResourceQuotaList) wrapLink() (data *resourceQuotaListLinkData, err error) {
+	if l == nil {
+		return
+	}
+	items := make([]*resourceQuotaData, len(l.items))
+	for i, item := range l.items {
+		items[i], err = item.wrap()
+		if err != nil {
+			return
+		}
+	}
+	data = new(resourceQuotaListLinkData)
+	data.Items = items
+	data.HREF = l.href
+	data.Kind = new(string)
+	if l.link {
+		*data.Kind = ResourceQuotaListLinkKind
+	} else {
+		*data.Kind = ResourceQuotaListKind
+	}
+	return
+}
+
+// unwrapLink is the function used internally to convert a JSON link to a list
+// of values of the 'resource_quota' type to a list.
+func (d *resourceQuotaListLinkData) unwrapLink() (list *ResourceQuotaList, err error) {
+	if d == nil {
+		return
+	}
+	items := make([]*ResourceQuota, len(d.Items))
+	for i, item := range d.Items {
+		items[i], err = item.unwrap()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ResourceQuotaList)
+	list.items = items
+	list.href = d.HREF
+	if d.Kind != nil {
+		switch *d.Kind {
+		case ResourceQuotaListKind:
+			list.link = false
+		case ResourceQuotaListLinkKind:
+			list.link = true
+		default:
+			err = fmt.Errorf(
+				"expected kind '%s' or '%s' but got '%s'",
+				ResourceQuotaListKind,
+				ResourceQuotaListLinkKind,
+				*d.Kind,
+			)
+			return
+		}
+	}
 	return
 }

--- a/pkg/client/accountsmgmt/v1/resource_quota_type.go
+++ b/pkg/client/accountsmgmt/v1/resource_quota_type.go
@@ -284,9 +284,57 @@ func (o *ResourceQuota) GetReserved() (value int, ok bool) {
 	return
 }
 
+// ResourceQuotaListKind is the name of the type used to represent list of
+// objects of type 'resource_quota'.
+const ResourceQuotaListKind = "ResourceQuotaList"
+
+// ResourceQuotaListLinkKind is the name of the type used to represent links
+// to list of objects of type 'resource_quota'.
+const ResourceQuotaListLinkKind = "ResourceQuotaListLink"
+
+// ResourceQuotaNilKind is the name of the type used to nil lists of
+// objects of type 'resource_quota'.
+const ResourceQuotaListNilKind = "ResourceQuotaListNil"
+
 // ResourceQuotaList is a list of values of the 'resource_quota' type.
 type ResourceQuotaList struct {
+	href  *string
+	link  bool
 	items []*ResourceQuota
+}
+
+// Kind returns the name of the type of the object.
+func (l *ResourceQuotaList) Kind() string {
+	if l == nil {
+		return ResourceQuotaListNilKind
+	}
+	if l.link {
+		return ResourceQuotaListLinkKind
+	}
+	return ResourceQuotaListKind
+}
+
+// Link returns true iif this is a link.
+func (l *ResourceQuotaList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *ResourceQuotaList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *ResourceQuotaList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/accountsmgmt/v1/role_binding_type.go
+++ b/pkg/client/accountsmgmt/v1/role_binding_type.go
@@ -212,9 +212,57 @@ func (o *RoleBinding) GetRole() (value *Role, ok bool) {
 	return
 }
 
+// RoleBindingListKind is the name of the type used to represent list of
+// objects of type 'role_binding'.
+const RoleBindingListKind = "RoleBindingList"
+
+// RoleBindingListLinkKind is the name of the type used to represent links
+// to list of objects of type 'role_binding'.
+const RoleBindingListLinkKind = "RoleBindingListLink"
+
+// RoleBindingNilKind is the name of the type used to nil lists of
+// objects of type 'role_binding'.
+const RoleBindingListNilKind = "RoleBindingListNil"
+
 // RoleBindingList is a list of values of the 'role_binding' type.
 type RoleBindingList struct {
+	href  *string
+	link  bool
 	items []*RoleBinding
+}
+
+// Kind returns the name of the type of the object.
+func (l *RoleBindingList) Kind() string {
+	if l == nil {
+		return RoleBindingListNilKind
+	}
+	if l.link {
+		return RoleBindingListLinkKind
+	}
+	return RoleBindingListKind
+}
+
+// Link returns true iif this is a link.
+func (l *RoleBindingList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *RoleBindingList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *RoleBindingList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/accountsmgmt/v1/role_list_reader.go
+++ b/pkg/client/accountsmgmt/v1/role_list_reader.go
@@ -20,6 +20,8 @@ limitations under the License.
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/accountsmgmt/v1
 
 import (
+	"fmt"
+
 	"github.com/openshift-online/uhc-sdk-go/pkg/client/helpers"
 )
 
@@ -46,12 +48,12 @@ func UnmarshalRoleList(source interface{}) (list *RoleList, err error) {
 
 // wrap is the method used internally to convert a list of values of the
 // 'role' value to a JSON document.
-func (o *RoleList) wrap() (data roleListData, err error) {
-	if o == nil {
+func (l *RoleList) wrap() (data roleListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(roleListData, len(o.items))
-	for i, item := range o.items {
+	data = make(roleListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return
@@ -75,5 +77,73 @@ func (d roleListData) unwrap() (list *RoleList, err error) {
 	}
 	list = new(RoleList)
 	list.items = items
+	return
+}
+
+// roleListLinkData is type used internally to marshal and unmarshal links
+// to lists of objects of type 'role'.
+type roleListLinkData struct {
+	Kind  *string     "json:\"kind,omitempty\""
+	HREF  *string     "json:\"href,omitempty\""
+	Items []*roleData "json:\"items,omitempty\""
+}
+
+// wrapLink is the method used internally to convert a list of values of the
+// 'role' value to a link.
+func (l *RoleList) wrapLink() (data *roleListLinkData, err error) {
+	if l == nil {
+		return
+	}
+	items := make([]*roleData, len(l.items))
+	for i, item := range l.items {
+		items[i], err = item.wrap()
+		if err != nil {
+			return
+		}
+	}
+	data = new(roleListLinkData)
+	data.Items = items
+	data.HREF = l.href
+	data.Kind = new(string)
+	if l.link {
+		*data.Kind = RoleListLinkKind
+	} else {
+		*data.Kind = RoleListKind
+	}
+	return
+}
+
+// unwrapLink is the function used internally to convert a JSON link to a list
+// of values of the 'role' type to a list.
+func (d *roleListLinkData) unwrapLink() (list *RoleList, err error) {
+	if d == nil {
+		return
+	}
+	items := make([]*Role, len(d.Items))
+	for i, item := range d.Items {
+		items[i], err = item.unwrap()
+		if err != nil {
+			return
+		}
+	}
+	list = new(RoleList)
+	list.items = items
+	list.href = d.HREF
+	if d.Kind != nil {
+		switch *d.Kind {
+		case RoleListKind:
+			list.link = false
+		case RoleListLinkKind:
+			list.link = true
+		default:
+			err = fmt.Errorf(
+				"expected kind '%s' or '%s' but got '%s'",
+				RoleListKind,
+				RoleListLinkKind,
+				*d.Kind,
+			)
+			return
+		}
+	}
 	return
 }

--- a/pkg/client/accountsmgmt/v1/role_reader.go
+++ b/pkg/client/accountsmgmt/v1/role_reader.go
@@ -65,6 +65,10 @@ func (o *Role) wrap() (data *roleData, err error) {
 		*data.Kind = RoleKind
 	}
 	data.Name = o.name
+	data.Permissions, err = o.permissions.wrap()
+	if err != nil {
+		return
+	}
 	return
 }
 
@@ -110,5 +114,9 @@ func (d *roleData) unwrap() (object *Role, err error) {
 		}
 	}
 	object.name = d.Name
+	object.permissions, err = d.Permissions.unwrap()
+	if err != nil {
+		return
+	}
 	return
 }

--- a/pkg/client/accountsmgmt/v1/role_type.go
+++ b/pkg/client/accountsmgmt/v1/role_type.go
@@ -140,9 +140,57 @@ func (o *Role) GetPermissions() (value *PermissionList, ok bool) {
 	return
 }
 
+// RoleListKind is the name of the type used to represent list of
+// objects of type 'role'.
+const RoleListKind = "RoleList"
+
+// RoleListLinkKind is the name of the type used to represent links
+// to list of objects of type 'role'.
+const RoleListLinkKind = "RoleListLink"
+
+// RoleNilKind is the name of the type used to nil lists of
+// objects of type 'role'.
+const RoleListNilKind = "RoleListNil"
+
 // RoleList is a list of values of the 'role' type.
 type RoleList struct {
+	href  *string
+	link  bool
 	items []*Role
+}
+
+// Kind returns the name of the type of the object.
+func (l *RoleList) Kind() string {
+	if l == nil {
+		return RoleListNilKind
+	}
+	if l.link {
+		return RoleListLinkKind
+	}
+	return RoleListKind
+}
+
+// Link returns true iif this is a link.
+func (l *RoleList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *RoleList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *RoleList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/accountsmgmt/v1/subscription_list_reader.go
+++ b/pkg/client/accountsmgmt/v1/subscription_list_reader.go
@@ -20,6 +20,8 @@ limitations under the License.
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/accountsmgmt/v1
 
 import (
+	"fmt"
+
 	"github.com/openshift-online/uhc-sdk-go/pkg/client/helpers"
 )
 
@@ -46,12 +48,12 @@ func UnmarshalSubscriptionList(source interface{}) (list *SubscriptionList, err 
 
 // wrap is the method used internally to convert a list of values of the
 // 'subscription' value to a JSON document.
-func (o *SubscriptionList) wrap() (data subscriptionListData, err error) {
-	if o == nil {
+func (l *SubscriptionList) wrap() (data subscriptionListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(subscriptionListData, len(o.items))
-	for i, item := range o.items {
+	data = make(subscriptionListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return
@@ -75,5 +77,73 @@ func (d subscriptionListData) unwrap() (list *SubscriptionList, err error) {
 	}
 	list = new(SubscriptionList)
 	list.items = items
+	return
+}
+
+// subscriptionListLinkData is type used internally to marshal and unmarshal links
+// to lists of objects of type 'subscription'.
+type subscriptionListLinkData struct {
+	Kind  *string             "json:\"kind,omitempty\""
+	HREF  *string             "json:\"href,omitempty\""
+	Items []*subscriptionData "json:\"items,omitempty\""
+}
+
+// wrapLink is the method used internally to convert a list of values of the
+// 'subscription' value to a link.
+func (l *SubscriptionList) wrapLink() (data *subscriptionListLinkData, err error) {
+	if l == nil {
+		return
+	}
+	items := make([]*subscriptionData, len(l.items))
+	for i, item := range l.items {
+		items[i], err = item.wrap()
+		if err != nil {
+			return
+		}
+	}
+	data = new(subscriptionListLinkData)
+	data.Items = items
+	data.HREF = l.href
+	data.Kind = new(string)
+	if l.link {
+		*data.Kind = SubscriptionListLinkKind
+	} else {
+		*data.Kind = SubscriptionListKind
+	}
+	return
+}
+
+// unwrapLink is the function used internally to convert a JSON link to a list
+// of values of the 'subscription' type to a list.
+func (d *subscriptionListLinkData) unwrapLink() (list *SubscriptionList, err error) {
+	if d == nil {
+		return
+	}
+	items := make([]*Subscription, len(d.Items))
+	for i, item := range d.Items {
+		items[i], err = item.unwrap()
+		if err != nil {
+			return
+		}
+	}
+	list = new(SubscriptionList)
+	list.items = items
+	list.href = d.HREF
+	if d.Kind != nil {
+		switch *d.Kind {
+		case SubscriptionListKind:
+			list.link = false
+		case SubscriptionListLinkKind:
+			list.link = true
+		default:
+			err = fmt.Errorf(
+				"expected kind '%s' or '%s' but got '%s'",
+				SubscriptionListKind,
+				SubscriptionListLinkKind,
+				*d.Kind,
+			)
+			return
+		}
+	}
 	return
 }

--- a/pkg/client/accountsmgmt/v1/subscription_type.go
+++ b/pkg/client/accountsmgmt/v1/subscription_type.go
@@ -240,9 +240,57 @@ func (o *Subscription) GetLastTelemetryDate() (value time.Time, ok bool) {
 	return
 }
 
+// SubscriptionListKind is the name of the type used to represent list of
+// objects of type 'subscription'.
+const SubscriptionListKind = "SubscriptionList"
+
+// SubscriptionListLinkKind is the name of the type used to represent links
+// to list of objects of type 'subscription'.
+const SubscriptionListLinkKind = "SubscriptionListLink"
+
+// SubscriptionNilKind is the name of the type used to nil lists of
+// objects of type 'subscription'.
+const SubscriptionListNilKind = "SubscriptionListNil"
+
 // SubscriptionList is a list of values of the 'subscription' type.
 type SubscriptionList struct {
+	href  *string
+	link  bool
 	items []*Subscription
+}
+
+// Kind returns the name of the type of the object.
+func (l *SubscriptionList) Kind() string {
+	if l == nil {
+		return SubscriptionListNilKind
+	}
+	if l.link {
+		return SubscriptionListLinkKind
+	}
+	return SubscriptionListKind
+}
+
+// Link returns true iif this is a link.
+func (l *SubscriptionList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *SubscriptionList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *SubscriptionList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/clustersmgmt/v1/admin_credentials_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/admin_credentials_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalAdminCredentialsList(source interface{}) (list *AdminCredentialsLi
 
 // wrap is the method used internally to convert a list of values of the
 // 'admin_credentials' value to a JSON document.
-func (o *AdminCredentialsList) wrap() (data adminCredentialsListData, err error) {
-	if o == nil {
+func (l *AdminCredentialsList) wrap() (data adminCredentialsListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(adminCredentialsListData, len(o.items))
-	for i, item := range o.items {
+	data = make(adminCredentialsListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/aws_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/aws_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalAWSList(source interface{}) (list *AWSList, err error) {
 
 // wrap is the method used internally to convert a list of values of the
 // 'AWS' value to a JSON document.
-func (o *AWSList) wrap() (data awsListData, err error) {
-	if o == nil {
+func (l *AWSList) wrap() (data awsListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(awsListData, len(o.items))
-	for i, item := range o.items {
+	data = make(awsListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/cloud_provider_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/cloud_provider_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalCloudProviderList(source interface{}) (list *CloudProviderList, er
 
 // wrap is the method used internally to convert a list of values of the
 // 'cloud_provider' value to a JSON document.
-func (o *CloudProviderList) wrap() (data cloudProviderListData, err error) {
-	if o == nil {
+func (l *CloudProviderList) wrap() (data cloudProviderListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(cloudProviderListData, len(o.items))
-	for i, item := range o.items {
+	data = make(cloudProviderListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/cloud_region_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/cloud_region_list_reader.go
@@ -20,6 +20,8 @@ limitations under the License.
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
 
 import (
+	"fmt"
+
 	"github.com/openshift-online/uhc-sdk-go/pkg/client/helpers"
 )
 
@@ -46,12 +48,12 @@ func UnmarshalCloudRegionList(source interface{}) (list *CloudRegionList, err er
 
 // wrap is the method used internally to convert a list of values of the
 // 'cloud_region' value to a JSON document.
-func (o *CloudRegionList) wrap() (data cloudRegionListData, err error) {
-	if o == nil {
+func (l *CloudRegionList) wrap() (data cloudRegionListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(cloudRegionListData, len(o.items))
-	for i, item := range o.items {
+	data = make(cloudRegionListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return
@@ -75,5 +77,73 @@ func (d cloudRegionListData) unwrap() (list *CloudRegionList, err error) {
 	}
 	list = new(CloudRegionList)
 	list.items = items
+	return
+}
+
+// cloudRegionListLinkData is type used internally to marshal and unmarshal links
+// to lists of objects of type 'cloud_region'.
+type cloudRegionListLinkData struct {
+	Kind  *string            "json:\"kind,omitempty\""
+	HREF  *string            "json:\"href,omitempty\""
+	Items []*cloudRegionData "json:\"items,omitempty\""
+}
+
+// wrapLink is the method used internally to convert a list of values of the
+// 'cloud_region' value to a link.
+func (l *CloudRegionList) wrapLink() (data *cloudRegionListLinkData, err error) {
+	if l == nil {
+		return
+	}
+	items := make([]*cloudRegionData, len(l.items))
+	for i, item := range l.items {
+		items[i], err = item.wrap()
+		if err != nil {
+			return
+		}
+	}
+	data = new(cloudRegionListLinkData)
+	data.Items = items
+	data.HREF = l.href
+	data.Kind = new(string)
+	if l.link {
+		*data.Kind = CloudRegionListLinkKind
+	} else {
+		*data.Kind = CloudRegionListKind
+	}
+	return
+}
+
+// unwrapLink is the function used internally to convert a JSON link to a list
+// of values of the 'cloud_region' type to a list.
+func (d *cloudRegionListLinkData) unwrapLink() (list *CloudRegionList, err error) {
+	if d == nil {
+		return
+	}
+	items := make([]*CloudRegion, len(d.Items))
+	for i, item := range d.Items {
+		items[i], err = item.unwrap()
+		if err != nil {
+			return
+		}
+	}
+	list = new(CloudRegionList)
+	list.items = items
+	list.href = d.HREF
+	if d.Kind != nil {
+		switch *d.Kind {
+		case CloudRegionListKind:
+			list.link = false
+		case CloudRegionListLinkKind:
+			list.link = true
+		default:
+			err = fmt.Errorf(
+				"expected kind '%s' or '%s' but got '%s'",
+				CloudRegionListKind,
+				CloudRegionListLinkKind,
+				*d.Kind,
+			)
+			return
+		}
+	}
 	return
 }

--- a/pkg/client/clustersmgmt/v1/cloud_region_type.go
+++ b/pkg/client/clustersmgmt/v1/cloud_region_type.go
@@ -170,9 +170,57 @@ func (o *CloudRegion) GetCloudProvider() (value *CloudProvider, ok bool) {
 	return
 }
 
+// CloudRegionListKind is the name of the type used to represent list of
+// objects of type 'cloud_region'.
+const CloudRegionListKind = "CloudRegionList"
+
+// CloudRegionListLinkKind is the name of the type used to represent links
+// to list of objects of type 'cloud_region'.
+const CloudRegionListLinkKind = "CloudRegionListLink"
+
+// CloudRegionNilKind is the name of the type used to nil lists of
+// objects of type 'cloud_region'.
+const CloudRegionListNilKind = "CloudRegionListNil"
+
 // CloudRegionList is a list of values of the 'cloud_region' type.
 type CloudRegionList struct {
+	href  *string
+	link  bool
 	items []*CloudRegion
+}
+
+// Kind returns the name of the type of the object.
+func (l *CloudRegionList) Kind() string {
+	if l == nil {
+		return CloudRegionListNilKind
+	}
+	if l.link {
+		return CloudRegionListLinkKind
+	}
+	return CloudRegionListKind
+}
+
+// Link returns true iif this is a link.
+func (l *CloudRegionList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *CloudRegionList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *CloudRegionList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/clustersmgmt/v1/cluster_api_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/cluster_api_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalClusterAPIList(source interface{}) (list *ClusterAPIList, err erro
 
 // wrap is the method used internally to convert a list of values of the
 // 'cluster_API' value to a JSON document.
-func (o *ClusterAPIList) wrap() (data clusterAPIListData, err error) {
-	if o == nil {
+func (l *ClusterAPIList) wrap() (data clusterAPIListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(clusterAPIListData, len(o.items))
-	for i, item := range o.items {
+	data = make(clusterAPIListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/cluster_console_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/cluster_console_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalClusterConsoleList(source interface{}) (list *ClusterConsoleList, 
 
 // wrap is the method used internally to convert a list of values of the
 // 'cluster_console' value to a JSON document.
-func (o *ClusterConsoleList) wrap() (data clusterConsoleListData, err error) {
-	if o == nil {
+func (l *ClusterConsoleList) wrap() (data clusterConsoleListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(clusterConsoleListData, len(o.items))
-	for i, item := range o.items {
+	data = make(clusterConsoleListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/cluster_credentials_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/cluster_credentials_list_reader.go
@@ -20,6 +20,8 @@ limitations under the License.
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
 
 import (
+	"fmt"
+
 	"github.com/openshift-online/uhc-sdk-go/pkg/client/helpers"
 )
 
@@ -46,12 +48,12 @@ func UnmarshalClusterCredentialsList(source interface{}) (list *ClusterCredentia
 
 // wrap is the method used internally to convert a list of values of the
 // 'cluster_credentials' value to a JSON document.
-func (o *ClusterCredentialsList) wrap() (data clusterCredentialsListData, err error) {
-	if o == nil {
+func (l *ClusterCredentialsList) wrap() (data clusterCredentialsListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(clusterCredentialsListData, len(o.items))
-	for i, item := range o.items {
+	data = make(clusterCredentialsListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return
@@ -75,5 +77,73 @@ func (d clusterCredentialsListData) unwrap() (list *ClusterCredentialsList, err 
 	}
 	list = new(ClusterCredentialsList)
 	list.items = items
+	return
+}
+
+// clusterCredentialsListLinkData is type used internally to marshal and unmarshal links
+// to lists of objects of type 'cluster_credentials'.
+type clusterCredentialsListLinkData struct {
+	Kind  *string                   "json:\"kind,omitempty\""
+	HREF  *string                   "json:\"href,omitempty\""
+	Items []*clusterCredentialsData "json:\"items,omitempty\""
+}
+
+// wrapLink is the method used internally to convert a list of values of the
+// 'cluster_credentials' value to a link.
+func (l *ClusterCredentialsList) wrapLink() (data *clusterCredentialsListLinkData, err error) {
+	if l == nil {
+		return
+	}
+	items := make([]*clusterCredentialsData, len(l.items))
+	for i, item := range l.items {
+		items[i], err = item.wrap()
+		if err != nil {
+			return
+		}
+	}
+	data = new(clusterCredentialsListLinkData)
+	data.Items = items
+	data.HREF = l.href
+	data.Kind = new(string)
+	if l.link {
+		*data.Kind = ClusterCredentialsListLinkKind
+	} else {
+		*data.Kind = ClusterCredentialsListKind
+	}
+	return
+}
+
+// unwrapLink is the function used internally to convert a JSON link to a list
+// of values of the 'cluster_credentials' type to a list.
+func (d *clusterCredentialsListLinkData) unwrapLink() (list *ClusterCredentialsList, err error) {
+	if d == nil {
+		return
+	}
+	items := make([]*ClusterCredentials, len(d.Items))
+	for i, item := range d.Items {
+		items[i], err = item.unwrap()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ClusterCredentialsList)
+	list.items = items
+	list.href = d.HREF
+	if d.Kind != nil {
+		switch *d.Kind {
+		case ClusterCredentialsListKind:
+			list.link = false
+		case ClusterCredentialsListLinkKind:
+			list.link = true
+		default:
+			err = fmt.Errorf(
+				"expected kind '%s' or '%s' but got '%s'",
+				ClusterCredentialsListKind,
+				ClusterCredentialsListLinkKind,
+				*d.Kind,
+			)
+			return
+		}
+	}
 	return
 }

--- a/pkg/client/clustersmgmt/v1/cluster_credentials_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_credentials_type.go
@@ -166,9 +166,57 @@ func (o *ClusterCredentials) GetAdmin() (value *AdminCredentials, ok bool) {
 	return
 }
 
+// ClusterCredentialsListKind is the name of the type used to represent list of
+// objects of type 'cluster_credentials'.
+const ClusterCredentialsListKind = "ClusterCredentialsList"
+
+// ClusterCredentialsListLinkKind is the name of the type used to represent links
+// to list of objects of type 'cluster_credentials'.
+const ClusterCredentialsListLinkKind = "ClusterCredentialsListLink"
+
+// ClusterCredentialsNilKind is the name of the type used to nil lists of
+// objects of type 'cluster_credentials'.
+const ClusterCredentialsListNilKind = "ClusterCredentialsListNil"
+
 // ClusterCredentialsList is a list of values of the 'cluster_credentials' type.
 type ClusterCredentialsList struct {
+	href  *string
+	link  bool
 	items []*ClusterCredentials
+}
+
+// Kind returns the name of the type of the object.
+func (l *ClusterCredentialsList) Kind() string {
+	if l == nil {
+		return ClusterCredentialsListNilKind
+	}
+	if l.link {
+		return ClusterCredentialsListLinkKind
+	}
+	return ClusterCredentialsListKind
+}
+
+// Link returns true iif this is a link.
+func (l *ClusterCredentialsList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *ClusterCredentialsList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *ClusterCredentialsList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/clustersmgmt/v1/cluster_log_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/cluster_log_list_reader.go
@@ -20,6 +20,8 @@ limitations under the License.
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
 
 import (
+	"fmt"
+
 	"github.com/openshift-online/uhc-sdk-go/pkg/client/helpers"
 )
 
@@ -46,12 +48,12 @@ func UnmarshalClusterLogList(source interface{}) (list *ClusterLogList, err erro
 
 // wrap is the method used internally to convert a list of values of the
 // 'cluster_log' value to a JSON document.
-func (o *ClusterLogList) wrap() (data clusterLogListData, err error) {
-	if o == nil {
+func (l *ClusterLogList) wrap() (data clusterLogListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(clusterLogListData, len(o.items))
-	for i, item := range o.items {
+	data = make(clusterLogListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return
@@ -75,5 +77,73 @@ func (d clusterLogListData) unwrap() (list *ClusterLogList, err error) {
 	}
 	list = new(ClusterLogList)
 	list.items = items
+	return
+}
+
+// clusterLogListLinkData is type used internally to marshal and unmarshal links
+// to lists of objects of type 'cluster_log'.
+type clusterLogListLinkData struct {
+	Kind  *string           "json:\"kind,omitempty\""
+	HREF  *string           "json:\"href,omitempty\""
+	Items []*clusterLogData "json:\"items,omitempty\""
+}
+
+// wrapLink is the method used internally to convert a list of values of the
+// 'cluster_log' value to a link.
+func (l *ClusterLogList) wrapLink() (data *clusterLogListLinkData, err error) {
+	if l == nil {
+		return
+	}
+	items := make([]*clusterLogData, len(l.items))
+	for i, item := range l.items {
+		items[i], err = item.wrap()
+		if err != nil {
+			return
+		}
+	}
+	data = new(clusterLogListLinkData)
+	data.Items = items
+	data.HREF = l.href
+	data.Kind = new(string)
+	if l.link {
+		*data.Kind = ClusterLogListLinkKind
+	} else {
+		*data.Kind = ClusterLogListKind
+	}
+	return
+}
+
+// unwrapLink is the function used internally to convert a JSON link to a list
+// of values of the 'cluster_log' type to a list.
+func (d *clusterLogListLinkData) unwrapLink() (list *ClusterLogList, err error) {
+	if d == nil {
+		return
+	}
+	items := make([]*ClusterLog, len(d.Items))
+	for i, item := range d.Items {
+		items[i], err = item.unwrap()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ClusterLogList)
+	list.items = items
+	list.href = d.HREF
+	if d.Kind != nil {
+		switch *d.Kind {
+		case ClusterLogListKind:
+			list.link = false
+		case ClusterLogListLinkKind:
+			list.link = true
+		default:
+			err = fmt.Errorf(
+				"expected kind '%s' or '%s' but got '%s'",
+				ClusterLogListKind,
+				ClusterLogListLinkKind,
+				*d.Kind,
+			)
+			return
+		}
+	}
 	return
 }

--- a/pkg/client/clustersmgmt/v1/cluster_log_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_log_type.go
@@ -116,9 +116,57 @@ func (o *ClusterLog) GetContent() (value string, ok bool) {
 	return
 }
 
+// ClusterLogListKind is the name of the type used to represent list of
+// objects of type 'cluster_log'.
+const ClusterLogListKind = "ClusterLogList"
+
+// ClusterLogListLinkKind is the name of the type used to represent links
+// to list of objects of type 'cluster_log'.
+const ClusterLogListLinkKind = "ClusterLogListLink"
+
+// ClusterLogNilKind is the name of the type used to nil lists of
+// objects of type 'cluster_log'.
+const ClusterLogListNilKind = "ClusterLogListNil"
+
 // ClusterLogList is a list of values of the 'cluster_log' type.
 type ClusterLogList struct {
+	href  *string
+	link  bool
 	items []*ClusterLog
+}
+
+// Kind returns the name of the type of the object.
+func (l *ClusterLogList) Kind() string {
+	if l == nil {
+		return ClusterLogListNilKind
+	}
+	if l.link {
+		return ClusterLogListLinkKind
+	}
+	return ClusterLogListKind
+}
+
+// Link returns true iif this is a link.
+func (l *ClusterLogList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *ClusterLogList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *ClusterLogList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/clustersmgmt/v1/cluster_metric_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/cluster_metric_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalClusterMetricList(source interface{}) (list *ClusterMetricList, er
 
 // wrap is the method used internally to convert a list of values of the
 // 'cluster_metric' value to a JSON document.
-func (o *ClusterMetricList) wrap() (data clusterMetricListData, err error) {
-	if o == nil {
+func (l *ClusterMetricList) wrap() (data clusterMetricListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(clusterMetricListData, len(o.items))
-	for i, item := range o.items {
+	data = make(clusterMetricListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/cluster_nodes_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/cluster_nodes_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalClusterNodesList(source interface{}) (list *ClusterNodesList, err 
 
 // wrap is the method used internally to convert a list of values of the
 // 'cluster_nodes' value to a JSON document.
-func (o *ClusterNodesList) wrap() (data clusterNodesListData, err error) {
-	if o == nil {
+func (l *ClusterNodesList) wrap() (data clusterNodesListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(clusterNodesListData, len(o.items))
-	for i, item := range o.items {
+	data = make(clusterNodesListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/cluster_reader.go
+++ b/pkg/client/clustersmgmt/v1/cluster_reader.go
@@ -29,35 +29,35 @@ import (
 // clusterData is the data structure used internally to marshal and unmarshal
 // objects of type 'cluster'.
 type clusterData struct {
-	Kind              *string                  "json:\"kind,omitempty\""
-	ID                *string                  "json:\"id,omitempty\""
-	HREF              *string                  "json:\"href,omitempty\""
-	Name              *string                  "json:\"name,omitempty\""
-	Flavour           *flavourData             "json:\"flavour,omitempty\""
-	Console           *clusterConsoleData      "json:\"console,omitempty\""
-	MultiAZ           *bool                    "json:\"multi_az,omitempty\""
-	Nodes             *clusterNodesData        "json:\"nodes,omitempty\""
-	API               *clusterAPIData          "json:\"api,omitempty\""
-	Region            *cloudRegionData         "json:\"region,omitempty\""
-	DisplayName       *string                  "json:\"display_name,omitempty\""
-	DNS               *dnsData                 "json:\"dns,omitempty\""
-	Properties        map[string]string        "json:\"properties,omitempty\""
-	State             *ClusterState            "json:\"state,omitempty\""
-	Managed           *bool                    "json:\"managed,omitempty\""
-	Memory            *clusterMetricData       "json:\"memory,omitempty\""
-	CPU               *clusterMetricData       "json:\"cpu,omitempty\""
-	Storage           *clusterMetricData       "json:\"storage,omitempty\""
-	ExternalID        *string                  "json:\"external_id,omitempty\""
-	AWS               *awsData                 "json:\"aws,omitempty\""
-	Network           *networkData             "json:\"network,omitempty\""
-	CreationTimestamp *time.Time               "json:\"creation_timestamp,omitempty\""
-	CloudProvider     *cloudProviderData       "json:\"cloud_provider,omitempty\""
-	OpenshiftVersion  *string                  "json:\"openshift_version,omitempty\""
-	Subscription      *subscriptionData        "json:\"subscription,omitempty\""
-	Groups            groupListData            "json:\"groups,omitempty\""
-	Creator           *string                  "json:\"creator,omitempty\""
-	Version           *versionData             "json:\"version,omitempty\""
-	IdentityProviders identityProviderListData "json:\"identity_providers,omitempty\""
+	Kind              *string                       "json:\"kind,omitempty\""
+	ID                *string                       "json:\"id,omitempty\""
+	HREF              *string                       "json:\"href,omitempty\""
+	Name              *string                       "json:\"name,omitempty\""
+	Flavour           *flavourData                  "json:\"flavour,omitempty\""
+	Console           *clusterConsoleData           "json:\"console,omitempty\""
+	MultiAZ           *bool                         "json:\"multi_az,omitempty\""
+	Nodes             *clusterNodesData             "json:\"nodes,omitempty\""
+	API               *clusterAPIData               "json:\"api,omitempty\""
+	Region            *cloudRegionData              "json:\"region,omitempty\""
+	DisplayName       *string                       "json:\"display_name,omitempty\""
+	DNS               *dnsData                      "json:\"dns,omitempty\""
+	Properties        map[string]string             "json:\"properties,omitempty\""
+	State             *ClusterState                 "json:\"state,omitempty\""
+	Managed           *bool                         "json:\"managed,omitempty\""
+	Memory            *clusterMetricData            "json:\"memory,omitempty\""
+	CPU               *clusterMetricData            "json:\"cpu,omitempty\""
+	Storage           *clusterMetricData            "json:\"storage,omitempty\""
+	ExternalID        *string                       "json:\"external_id,omitempty\""
+	AWS               *awsData                      "json:\"aws,omitempty\""
+	Network           *networkData                  "json:\"network,omitempty\""
+	CreationTimestamp *time.Time                    "json:\"creation_timestamp,omitempty\""
+	CloudProvider     *cloudProviderData            "json:\"cloud_provider,omitempty\""
+	OpenshiftVersion  *string                       "json:\"openshift_version,omitempty\""
+	Subscription      *subscriptionData             "json:\"subscription,omitempty\""
+	Groups            *groupListLinkData            "json:\"groups,omitempty\""
+	Creator           *string                       "json:\"creator,omitempty\""
+	Version           *versionData                  "json:\"version,omitempty\""
+	IdentityProviders *identityProviderListLinkData "json:\"identity_providers,omitempty\""
 }
 
 // MarshalCluster writes a value of the 'cluster' to the given target,
@@ -150,8 +150,16 @@ func (o *Cluster) wrap() (data *clusterData, err error) {
 	if err != nil {
 		return
 	}
+	data.Groups, err = o.groups.wrapLink()
+	if err != nil {
+		return
+	}
 	data.Creator = o.creator
 	data.Version, err = o.version.wrap()
+	if err != nil {
+		return
+	}
+	data.IdentityProviders, err = o.identityProviders.wrapLink()
 	if err != nil {
 		return
 	}
@@ -260,8 +268,16 @@ func (d *clusterData) unwrap() (object *Cluster, err error) {
 	if err != nil {
 		return
 	}
+	object.groups, err = d.Groups.unwrapLink()
+	if err != nil {
+		return
+	}
 	object.creator = d.Creator
 	object.version, err = d.Version.unwrap()
+	if err != nil {
+		return
+	}
+	object.identityProviders, err = d.IdentityProviders.unwrapLink()
 	if err != nil {
 		return
 	}

--- a/pkg/client/clustersmgmt/v1/cluster_registration_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/cluster_registration_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalClusterRegistrationList(source interface{}) (list *ClusterRegistra
 
 // wrap is the method used internally to convert a list of values of the
 // 'cluster_registration' value to a JSON document.
-func (o *ClusterRegistrationList) wrap() (data clusterRegistrationListData, err error) {
-	if o == nil {
+func (l *ClusterRegistrationList) wrap() (data clusterRegistrationListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(clusterRegistrationListData, len(o.items))
-	for i, item := range o.items {
+	data = make(clusterRegistrationListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/cluster_status_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/cluster_status_list_reader.go
@@ -20,6 +20,8 @@ limitations under the License.
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
 
 import (
+	"fmt"
+
 	"github.com/openshift-online/uhc-sdk-go/pkg/client/helpers"
 )
 
@@ -46,12 +48,12 @@ func UnmarshalClusterStatusList(source interface{}) (list *ClusterStatusList, er
 
 // wrap is the method used internally to convert a list of values of the
 // 'cluster_status' value to a JSON document.
-func (o *ClusterStatusList) wrap() (data clusterStatusListData, err error) {
-	if o == nil {
+func (l *ClusterStatusList) wrap() (data clusterStatusListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(clusterStatusListData, len(o.items))
-	for i, item := range o.items {
+	data = make(clusterStatusListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return
@@ -75,5 +77,73 @@ func (d clusterStatusListData) unwrap() (list *ClusterStatusList, err error) {
 	}
 	list = new(ClusterStatusList)
 	list.items = items
+	return
+}
+
+// clusterStatusListLinkData is type used internally to marshal and unmarshal links
+// to lists of objects of type 'cluster_status'.
+type clusterStatusListLinkData struct {
+	Kind  *string              "json:\"kind,omitempty\""
+	HREF  *string              "json:\"href,omitempty\""
+	Items []*clusterStatusData "json:\"items,omitempty\""
+}
+
+// wrapLink is the method used internally to convert a list of values of the
+// 'cluster_status' value to a link.
+func (l *ClusterStatusList) wrapLink() (data *clusterStatusListLinkData, err error) {
+	if l == nil {
+		return
+	}
+	items := make([]*clusterStatusData, len(l.items))
+	for i, item := range l.items {
+		items[i], err = item.wrap()
+		if err != nil {
+			return
+		}
+	}
+	data = new(clusterStatusListLinkData)
+	data.Items = items
+	data.HREF = l.href
+	data.Kind = new(string)
+	if l.link {
+		*data.Kind = ClusterStatusListLinkKind
+	} else {
+		*data.Kind = ClusterStatusListKind
+	}
+	return
+}
+
+// unwrapLink is the function used internally to convert a JSON link to a list
+// of values of the 'cluster_status' type to a list.
+func (d *clusterStatusListLinkData) unwrapLink() (list *ClusterStatusList, err error) {
+	if d == nil {
+		return
+	}
+	items := make([]*ClusterStatus, len(d.Items))
+	for i, item := range d.Items {
+		items[i], err = item.unwrap()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ClusterStatusList)
+	list.items = items
+	list.href = d.HREF
+	if d.Kind != nil {
+		switch *d.Kind {
+		case ClusterStatusListKind:
+			list.link = false
+		case ClusterStatusListLinkKind:
+			list.link = true
+		default:
+			err = fmt.Errorf(
+				"expected kind '%s' or '%s' but got '%s'",
+				ClusterStatusListKind,
+				ClusterStatusListLinkKind,
+				*d.Kind,
+			)
+			return
+		}
+	}
 	return
 }

--- a/pkg/client/clustersmgmt/v1/cluster_status_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_status_type.go
@@ -140,9 +140,57 @@ func (o *ClusterStatus) GetDescription() (value string, ok bool) {
 	return
 }
 
+// ClusterStatusListKind is the name of the type used to represent list of
+// objects of type 'cluster_status'.
+const ClusterStatusListKind = "ClusterStatusList"
+
+// ClusterStatusListLinkKind is the name of the type used to represent links
+// to list of objects of type 'cluster_status'.
+const ClusterStatusListLinkKind = "ClusterStatusListLink"
+
+// ClusterStatusNilKind is the name of the type used to nil lists of
+// objects of type 'cluster_status'.
+const ClusterStatusListNilKind = "ClusterStatusListNil"
+
 // ClusterStatusList is a list of values of the 'cluster_status' type.
 type ClusterStatusList struct {
+	href  *string
+	link  bool
 	items []*ClusterStatus
+}
+
+// Kind returns the name of the type of the object.
+func (l *ClusterStatusList) Kind() string {
+	if l == nil {
+		return ClusterStatusListNilKind
+	}
+	if l.link {
+		return ClusterStatusListLinkKind
+	}
+	return ClusterStatusListKind
+}
+
+// Link returns true iif this is a link.
+func (l *ClusterStatusList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *ClusterStatusList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *ClusterStatusList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/clustersmgmt/v1/cluster_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_type.go
@@ -780,9 +780,57 @@ func (o *Cluster) GetIdentityProviders() (value *IdentityProviderList, ok bool) 
 	return
 }
 
+// ClusterListKind is the name of the type used to represent list of
+// objects of type 'cluster'.
+const ClusterListKind = "ClusterList"
+
+// ClusterListLinkKind is the name of the type used to represent links
+// to list of objects of type 'cluster'.
+const ClusterListLinkKind = "ClusterListLink"
+
+// ClusterNilKind is the name of the type used to nil lists of
+// objects of type 'cluster'.
+const ClusterListNilKind = "ClusterListNil"
+
 // ClusterList is a list of values of the 'cluster' type.
 type ClusterList struct {
+	href  *string
+	link  bool
 	items []*Cluster
+}
+
+// Kind returns the name of the type of the object.
+func (l *ClusterList) Kind() string {
+	if l == nil {
+		return ClusterListNilKind
+	}
+	if l.link {
+		return ClusterListLinkKind
+	}
+	return ClusterListKind
+}
+
+// Link returns true iif this is a link.
+func (l *ClusterList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *ClusterList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *ClusterList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/clustersmgmt/v1/dashboard_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/dashboard_list_reader.go
@@ -20,6 +20,8 @@ limitations under the License.
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
 
 import (
+	"fmt"
+
 	"github.com/openshift-online/uhc-sdk-go/pkg/client/helpers"
 )
 
@@ -46,12 +48,12 @@ func UnmarshalDashboardList(source interface{}) (list *DashboardList, err error)
 
 // wrap is the method used internally to convert a list of values of the
 // 'dashboard' value to a JSON document.
-func (o *DashboardList) wrap() (data dashboardListData, err error) {
-	if o == nil {
+func (l *DashboardList) wrap() (data dashboardListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(dashboardListData, len(o.items))
-	for i, item := range o.items {
+	data = make(dashboardListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return
@@ -75,5 +77,73 @@ func (d dashboardListData) unwrap() (list *DashboardList, err error) {
 	}
 	list = new(DashboardList)
 	list.items = items
+	return
+}
+
+// dashboardListLinkData is type used internally to marshal and unmarshal links
+// to lists of objects of type 'dashboard'.
+type dashboardListLinkData struct {
+	Kind  *string          "json:\"kind,omitempty\""
+	HREF  *string          "json:\"href,omitempty\""
+	Items []*dashboardData "json:\"items,omitempty\""
+}
+
+// wrapLink is the method used internally to convert a list of values of the
+// 'dashboard' value to a link.
+func (l *DashboardList) wrapLink() (data *dashboardListLinkData, err error) {
+	if l == nil {
+		return
+	}
+	items := make([]*dashboardData, len(l.items))
+	for i, item := range l.items {
+		items[i], err = item.wrap()
+		if err != nil {
+			return
+		}
+	}
+	data = new(dashboardListLinkData)
+	data.Items = items
+	data.HREF = l.href
+	data.Kind = new(string)
+	if l.link {
+		*data.Kind = DashboardListLinkKind
+	} else {
+		*data.Kind = DashboardListKind
+	}
+	return
+}
+
+// unwrapLink is the function used internally to convert a JSON link to a list
+// of values of the 'dashboard' type to a list.
+func (d *dashboardListLinkData) unwrapLink() (list *DashboardList, err error) {
+	if d == nil {
+		return
+	}
+	items := make([]*Dashboard, len(d.Items))
+	for i, item := range d.Items {
+		items[i], err = item.unwrap()
+		if err != nil {
+			return
+		}
+	}
+	list = new(DashboardList)
+	list.items = items
+	list.href = d.HREF
+	if d.Kind != nil {
+		switch *d.Kind {
+		case DashboardListKind:
+			list.link = false
+		case DashboardListLinkKind:
+			list.link = true
+		default:
+			err = fmt.Errorf(
+				"expected kind '%s' or '%s' but got '%s'",
+				DashboardListKind,
+				DashboardListLinkKind,
+				*d.Kind,
+			)
+			return
+		}
+	}
 	return
 }

--- a/pkg/client/clustersmgmt/v1/dashboard_reader.go
+++ b/pkg/client/clustersmgmt/v1/dashboard_reader.go
@@ -63,6 +63,10 @@ func (o *Dashboard) wrap() (data *dashboardData, err error) {
 	} else {
 		*data.Kind = DashboardKind
 	}
+	data.Metrics, err = o.metrics.wrap()
+	if err != nil {
+		return
+	}
 	return
 }
 
@@ -106,6 +110,10 @@ func (d *dashboardData) unwrap() (object *Dashboard, err error) {
 			)
 			return
 		}
+	}
+	object.metrics, err = d.Metrics.unwrap()
+	if err != nil {
+		return
 	}
 	return
 }

--- a/pkg/client/clustersmgmt/v1/dashboard_type.go
+++ b/pkg/client/clustersmgmt/v1/dashboard_type.go
@@ -116,9 +116,57 @@ func (o *Dashboard) GetMetrics() (value *MetricList, ok bool) {
 	return
 }
 
+// DashboardListKind is the name of the type used to represent list of
+// objects of type 'dashboard'.
+const DashboardListKind = "DashboardList"
+
+// DashboardListLinkKind is the name of the type used to represent links
+// to list of objects of type 'dashboard'.
+const DashboardListLinkKind = "DashboardListLink"
+
+// DashboardNilKind is the name of the type used to nil lists of
+// objects of type 'dashboard'.
+const DashboardListNilKind = "DashboardListNil"
+
 // DashboardList is a list of values of the 'dashboard' type.
 type DashboardList struct {
+	href  *string
+	link  bool
 	items []*Dashboard
+}
+
+// Kind returns the name of the type of the object.
+func (l *DashboardList) Kind() string {
+	if l == nil {
+		return DashboardListNilKind
+	}
+	if l.link {
+		return DashboardListLinkKind
+	}
+	return DashboardListKind
+}
+
+// Link returns true iif this is a link.
+func (l *DashboardList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *DashboardList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *DashboardList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/clustersmgmt/v1/dns_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/dns_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalDNSList(source interface{}) (list *DNSList, err error) {
 
 // wrap is the method used internally to convert a list of values of the
 // 'DNS' value to a JSON document.
-func (o *DNSList) wrap() (data dnsListData, err error) {
-	if o == nil {
+func (l *DNSList) wrap() (data dnsListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(dnsListData, len(o.items))
-	for i, item := range o.items {
+	data = make(dnsListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/flavour_type.go
+++ b/pkg/client/clustersmgmt/v1/flavour_type.go
@@ -233,9 +233,57 @@ func (o *Flavour) GetNetwork() (value *Network, ok bool) {
 	return
 }
 
+// FlavourListKind is the name of the type used to represent list of
+// objects of type 'flavour'.
+const FlavourListKind = "FlavourList"
+
+// FlavourListLinkKind is the name of the type used to represent links
+// to list of objects of type 'flavour'.
+const FlavourListLinkKind = "FlavourListLink"
+
+// FlavourNilKind is the name of the type used to nil lists of
+// objects of type 'flavour'.
+const FlavourListNilKind = "FlavourListNil"
+
 // FlavourList is a list of values of the 'flavour' type.
 type FlavourList struct {
+	href  *string
+	link  bool
 	items []*Flavour
+}
+
+// Kind returns the name of the type of the object.
+func (l *FlavourList) Kind() string {
+	if l == nil {
+		return FlavourListNilKind
+	}
+	if l.link {
+		return FlavourListLinkKind
+	}
+	return FlavourListKind
+}
+
+// Link returns true iif this is a link.
+func (l *FlavourList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *FlavourList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *FlavourList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/clustersmgmt/v1/github_identity_provider_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/github_identity_provider_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalGithubIdentityProviderList(source interface{}) (list *GithubIdenti
 
 // wrap is the method used internally to convert a list of values of the
 // 'github_identity_provider' value to a JSON document.
-func (o *GithubIdentityProviderList) wrap() (data githubIdentityProviderListData, err error) {
-	if o == nil {
+func (l *GithubIdentityProviderList) wrap() (data githubIdentityProviderListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(githubIdentityProviderListData, len(o.items))
-	for i, item := range o.items {
+	data = make(githubIdentityProviderListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/gitlab_identity_provider_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/gitlab_identity_provider_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalGitlabIdentityProviderList(source interface{}) (list *GitlabIdenti
 
 // wrap is the method used internally to convert a list of values of the
 // 'gitlab_identity_provider' value to a JSON document.
-func (o *GitlabIdentityProviderList) wrap() (data gitlabIdentityProviderListData, err error) {
-	if o == nil {
+func (l *GitlabIdentityProviderList) wrap() (data gitlabIdentityProviderListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(gitlabIdentityProviderListData, len(o.items))
-	for i, item := range o.items {
+	data = make(gitlabIdentityProviderListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/google_identity_provider_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/google_identity_provider_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalGoogleIdentityProviderList(source interface{}) (list *GoogleIdenti
 
 // wrap is the method used internally to convert a list of values of the
 // 'google_identity_provider' value to a JSON document.
-func (o *GoogleIdentityProviderList) wrap() (data googleIdentityProviderListData, err error) {
-	if o == nil {
+func (l *GoogleIdentityProviderList) wrap() (data googleIdentityProviderListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(googleIdentityProviderListData, len(o.items))
-	for i, item := range o.items {
+	data = make(googleIdentityProviderListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/group_reader.go
+++ b/pkg/client/clustersmgmt/v1/group_reader.go
@@ -28,10 +28,10 @@ import (
 // groupData is the data structure used internally to marshal and unmarshal
 // objects of type 'group'.
 type groupData struct {
-	Kind  *string      "json:\"kind,omitempty\""
-	ID    *string      "json:\"id,omitempty\""
-	HREF  *string      "json:\"href,omitempty\""
-	Users userListData "json:\"users,omitempty\""
+	Kind  *string           "json:\"kind,omitempty\""
+	ID    *string           "json:\"id,omitempty\""
+	HREF  *string           "json:\"href,omitempty\""
+	Users *userListLinkData "json:\"users,omitempty\""
 }
 
 // MarshalGroup writes a value of the 'group' to the given target,
@@ -62,6 +62,10 @@ func (o *Group) wrap() (data *groupData, err error) {
 		*data.Kind = GroupLinkKind
 	} else {
 		*data.Kind = GroupKind
+	}
+	data.Users, err = o.users.wrapLink()
+	if err != nil {
+		return
 	}
 	return
 }
@@ -106,6 +110,10 @@ func (d *groupData) unwrap() (object *Group, err error) {
 			)
 			return
 		}
+	}
+	object.users, err = d.Users.unwrapLink()
+	if err != nil {
+		return
 	}
 	return
 }

--- a/pkg/client/clustersmgmt/v1/group_type.go
+++ b/pkg/client/clustersmgmt/v1/group_type.go
@@ -116,9 +116,57 @@ func (o *Group) GetUsers() (value *UserList, ok bool) {
 	return
 }
 
+// GroupListKind is the name of the type used to represent list of
+// objects of type 'group'.
+const GroupListKind = "GroupList"
+
+// GroupListLinkKind is the name of the type used to represent links
+// to list of objects of type 'group'.
+const GroupListLinkKind = "GroupListLink"
+
+// GroupNilKind is the name of the type used to nil lists of
+// objects of type 'group'.
+const GroupListNilKind = "GroupListNil"
+
 // GroupList is a list of values of the 'group' type.
 type GroupList struct {
+	href  *string
+	link  bool
 	items []*Group
+}
+
+// Kind returns the name of the type of the object.
+func (l *GroupList) Kind() string {
+	if l == nil {
+		return GroupListNilKind
+	}
+	if l.link {
+		return GroupListLinkKind
+	}
+	return GroupListKind
+}
+
+// Link returns true iif this is a link.
+func (l *GroupList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *GroupList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *GroupList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/clustersmgmt/v1/identity_provider_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/identity_provider_list_reader.go
@@ -20,6 +20,8 @@ limitations under the License.
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
 
 import (
+	"fmt"
+
 	"github.com/openshift-online/uhc-sdk-go/pkg/client/helpers"
 )
 
@@ -46,12 +48,12 @@ func UnmarshalIdentityProviderList(source interface{}) (list *IdentityProviderLi
 
 // wrap is the method used internally to convert a list of values of the
 // 'identity_provider' value to a JSON document.
-func (o *IdentityProviderList) wrap() (data identityProviderListData, err error) {
-	if o == nil {
+func (l *IdentityProviderList) wrap() (data identityProviderListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(identityProviderListData, len(o.items))
-	for i, item := range o.items {
+	data = make(identityProviderListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return
@@ -75,5 +77,73 @@ func (d identityProviderListData) unwrap() (list *IdentityProviderList, err erro
 	}
 	list = new(IdentityProviderList)
 	list.items = items
+	return
+}
+
+// identityProviderListLinkData is type used internally to marshal and unmarshal links
+// to lists of objects of type 'identity_provider'.
+type identityProviderListLinkData struct {
+	Kind  *string                 "json:\"kind,omitempty\""
+	HREF  *string                 "json:\"href,omitempty\""
+	Items []*identityProviderData "json:\"items,omitempty\""
+}
+
+// wrapLink is the method used internally to convert a list of values of the
+// 'identity_provider' value to a link.
+func (l *IdentityProviderList) wrapLink() (data *identityProviderListLinkData, err error) {
+	if l == nil {
+		return
+	}
+	items := make([]*identityProviderData, len(l.items))
+	for i, item := range l.items {
+		items[i], err = item.wrap()
+		if err != nil {
+			return
+		}
+	}
+	data = new(identityProviderListLinkData)
+	data.Items = items
+	data.HREF = l.href
+	data.Kind = new(string)
+	if l.link {
+		*data.Kind = IdentityProviderListLinkKind
+	} else {
+		*data.Kind = IdentityProviderListKind
+	}
+	return
+}
+
+// unwrapLink is the function used internally to convert a JSON link to a list
+// of values of the 'identity_provider' type to a list.
+func (d *identityProviderListLinkData) unwrapLink() (list *IdentityProviderList, err error) {
+	if d == nil {
+		return
+	}
+	items := make([]*IdentityProvider, len(d.Items))
+	for i, item := range d.Items {
+		items[i], err = item.unwrap()
+		if err != nil {
+			return
+		}
+	}
+	list = new(IdentityProviderList)
+	list.items = items
+	list.href = d.HREF
+	if d.Kind != nil {
+		switch *d.Kind {
+		case IdentityProviderListKind:
+			list.link = false
+		case IdentityProviderListLinkKind:
+			list.link = true
+		default:
+			err = fmt.Errorf(
+				"expected kind '%s' or '%s' but got '%s'",
+				IdentityProviderListKind,
+				IdentityProviderListLinkKind,
+				*d.Kind,
+			)
+			return
+		}
+	}
 	return
 }

--- a/pkg/client/clustersmgmt/v1/identity_provider_type.go
+++ b/pkg/client/clustersmgmt/v1/identity_provider_type.go
@@ -342,9 +342,57 @@ func (o *IdentityProvider) GetOpenID() (value *OpenIdidentityProvider, ok bool) 
 	return
 }
 
+// IdentityProviderListKind is the name of the type used to represent list of
+// objects of type 'identity_provider'.
+const IdentityProviderListKind = "IdentityProviderList"
+
+// IdentityProviderListLinkKind is the name of the type used to represent links
+// to list of objects of type 'identity_provider'.
+const IdentityProviderListLinkKind = "IdentityProviderListLink"
+
+// IdentityProviderNilKind is the name of the type used to nil lists of
+// objects of type 'identity_provider'.
+const IdentityProviderListNilKind = "IdentityProviderListNil"
+
 // IdentityProviderList is a list of values of the 'identity_provider' type.
 type IdentityProviderList struct {
+	href  *string
+	link  bool
 	items []*IdentityProvider
+}
+
+// Kind returns the name of the type of the object.
+func (l *IdentityProviderList) Kind() string {
+	if l == nil {
+		return IdentityProviderListNilKind
+	}
+	if l.link {
+		return IdentityProviderListLinkKind
+	}
+	return IdentityProviderListKind
+}
+
+// Link returns true iif this is a link.
+func (l *IdentityProviderList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *IdentityProviderList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *IdentityProviderList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/clustersmgmt/v1/ldapattributes_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/ldapattributes_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalLdapattributesList(source interface{}) (list *LdapattributesList, 
 
 // wrap is the method used internally to convert a list of values of the
 // 'ldapattributes' value to a JSON document.
-func (o *LdapattributesList) wrap() (data ldapattributesListData, err error) {
-	if o == nil {
+func (l *LdapattributesList) wrap() (data ldapattributesListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(ldapattributesListData, len(o.items))
-	for i, item := range o.items {
+	data = make(ldapattributesListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/ldapidentity_provider_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/ldapidentity_provider_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalLdapidentityProviderList(source interface{}) (list *LdapidentityPr
 
 // wrap is the method used internally to convert a list of values of the
 // 'ldapidentity_provider' value to a JSON document.
-func (o *LdapidentityProviderList) wrap() (data ldapidentityProviderListData, err error) {
-	if o == nil {
+func (l *LdapidentityProviderList) wrap() (data ldapidentityProviderListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(ldapidentityProviderListData, len(o.items))
-	for i, item := range o.items {
+	data = make(ldapidentityProviderListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/metric_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/metric_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalMetricList(source interface{}) (list *MetricList, err error) {
 
 // wrap is the method used internally to convert a list of values of the
 // 'metric' value to a JSON document.
-func (o *MetricList) wrap() (data metricListData, err error) {
-	if o == nil {
+func (l *MetricList) wrap() (data metricListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(metricListData, len(o.items))
-	for i, item := range o.items {
+	data = make(metricListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/metric_reader.go
+++ b/pkg/client/clustersmgmt/v1/metric_reader.go
@@ -52,6 +52,10 @@ func (o *Metric) wrap() (data *metricData, err error) {
 	}
 	data = new(metricData)
 	data.Name = o.name
+	data.Vector, err = o.vector.wrap()
+	if err != nil {
+		return
+	}
 	return
 }
 
@@ -79,5 +83,9 @@ func (d *metricData) unwrap() (object *Metric, err error) {
 	}
 	object = new(Metric)
 	object.name = d.Name
+	object.vector, err = d.Vector.unwrap()
+	if err != nil {
+		return
+	}
 	return
 }

--- a/pkg/client/clustersmgmt/v1/network_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/network_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalNetworkList(source interface{}) (list *NetworkList, err error) {
 
 // wrap is the method used internally to convert a list of values of the
 // 'network' value to a JSON document.
-func (o *NetworkList) wrap() (data networkListData, err error) {
-	if o == nil {
+func (l *NetworkList) wrap() (data networkListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(networkListData, len(o.items))
-	for i, item := range o.items {
+	data = make(networkListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/open_idclaims_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/open_idclaims_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalOpenIdclaimsList(source interface{}) (list *OpenIdclaimsList, err 
 
 // wrap is the method used internally to convert a list of values of the
 // 'open_idclaims' value to a JSON document.
-func (o *OpenIdclaimsList) wrap() (data openIdclaimsListData, err error) {
-	if o == nil {
+func (l *OpenIdclaimsList) wrap() (data openIdclaimsListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(openIdclaimsListData, len(o.items))
-	for i, item := range o.items {
+	data = make(openIdclaimsListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/open_ididentity_provider_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/open_ididentity_provider_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalOpenIdidentityProviderList(source interface{}) (list *OpenIdidenti
 
 // wrap is the method used internally to convert a list of values of the
 // 'open_ididentity_provider' value to a JSON document.
-func (o *OpenIdidentityProviderList) wrap() (data openIdidentityProviderListData, err error) {
-	if o == nil {
+func (l *OpenIdidentityProviderList) wrap() (data openIdidentityProviderListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(openIdidentityProviderListData, len(o.items))
-	for i, item := range o.items {
+	data = make(openIdidentityProviderListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/open_idurls_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/open_idurls_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalOpenIdurlsList(source interface{}) (list *OpenIdurlsList, err erro
 
 // wrap is the method used internally to convert a list of values of the
 // 'open_idurls' value to a JSON document.
-func (o *OpenIdurlsList) wrap() (data openIdurlsListData, err error) {
-	if o == nil {
+func (l *OpenIdurlsList) wrap() (data openIdurlsListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(openIdurlsListData, len(o.items))
-	for i, item := range o.items {
+	data = make(openIdurlsListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/sample_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/sample_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalSampleList(source interface{}) (list *SampleList, err error) {
 
 // wrap is the method used internally to convert a list of values of the
 // 'sample' value to a JSON document.
-func (o *SampleList) wrap() (data sampleListData, err error) {
-	if o == nil {
+func (l *SampleList) wrap() (data sampleListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(sampleListData, len(o.items))
-	for i, item := range o.items {
+	data = make(sampleListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/sshcredentials_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/sshcredentials_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalSshcredentialsList(source interface{}) (list *SshcredentialsList, 
 
 // wrap is the method used internally to convert a list of values of the
 // 'sshcredentials' value to a JSON document.
-func (o *SshcredentialsList) wrap() (data sshcredentialsListData, err error) {
-	if o == nil {
+func (l *SshcredentialsList) wrap() (data sshcredentialsListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(sshcredentialsListData, len(o.items))
-	for i, item := range o.items {
+	data = make(sshcredentialsListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/subscription_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/subscription_list_reader.go
@@ -20,6 +20,8 @@ limitations under the License.
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
 
 import (
+	"fmt"
+
 	"github.com/openshift-online/uhc-sdk-go/pkg/client/helpers"
 )
 
@@ -46,12 +48,12 @@ func UnmarshalSubscriptionList(source interface{}) (list *SubscriptionList, err 
 
 // wrap is the method used internally to convert a list of values of the
 // 'subscription' value to a JSON document.
-func (o *SubscriptionList) wrap() (data subscriptionListData, err error) {
-	if o == nil {
+func (l *SubscriptionList) wrap() (data subscriptionListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(subscriptionListData, len(o.items))
-	for i, item := range o.items {
+	data = make(subscriptionListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return
@@ -75,5 +77,73 @@ func (d subscriptionListData) unwrap() (list *SubscriptionList, err error) {
 	}
 	list = new(SubscriptionList)
 	list.items = items
+	return
+}
+
+// subscriptionListLinkData is type used internally to marshal and unmarshal links
+// to lists of objects of type 'subscription'.
+type subscriptionListLinkData struct {
+	Kind  *string             "json:\"kind,omitempty\""
+	HREF  *string             "json:\"href,omitempty\""
+	Items []*subscriptionData "json:\"items,omitempty\""
+}
+
+// wrapLink is the method used internally to convert a list of values of the
+// 'subscription' value to a link.
+func (l *SubscriptionList) wrapLink() (data *subscriptionListLinkData, err error) {
+	if l == nil {
+		return
+	}
+	items := make([]*subscriptionData, len(l.items))
+	for i, item := range l.items {
+		items[i], err = item.wrap()
+		if err != nil {
+			return
+		}
+	}
+	data = new(subscriptionListLinkData)
+	data.Items = items
+	data.HREF = l.href
+	data.Kind = new(string)
+	if l.link {
+		*data.Kind = SubscriptionListLinkKind
+	} else {
+		*data.Kind = SubscriptionListKind
+	}
+	return
+}
+
+// unwrapLink is the function used internally to convert a JSON link to a list
+// of values of the 'subscription' type to a list.
+func (d *subscriptionListLinkData) unwrapLink() (list *SubscriptionList, err error) {
+	if d == nil {
+		return
+	}
+	items := make([]*Subscription, len(d.Items))
+	for i, item := range d.Items {
+		items[i], err = item.unwrap()
+		if err != nil {
+			return
+		}
+	}
+	list = new(SubscriptionList)
+	list.items = items
+	list.href = d.HREF
+	if d.Kind != nil {
+		switch *d.Kind {
+		case SubscriptionListKind:
+			list.link = false
+		case SubscriptionListLinkKind:
+			list.link = true
+		default:
+			err = fmt.Errorf(
+				"expected kind '%s' or '%s' but got '%s'",
+				SubscriptionListKind,
+				SubscriptionListLinkKind,
+				*d.Kind,
+			)
+			return
+		}
+	}
 	return
 }

--- a/pkg/client/clustersmgmt/v1/subscription_type.go
+++ b/pkg/client/clustersmgmt/v1/subscription_type.go
@@ -92,9 +92,57 @@ func (o *Subscription) GetHREF() (value string, ok bool) {
 	return
 }
 
+// SubscriptionListKind is the name of the type used to represent list of
+// objects of type 'subscription'.
+const SubscriptionListKind = "SubscriptionList"
+
+// SubscriptionListLinkKind is the name of the type used to represent links
+// to list of objects of type 'subscription'.
+const SubscriptionListLinkKind = "SubscriptionListLink"
+
+// SubscriptionNilKind is the name of the type used to nil lists of
+// objects of type 'subscription'.
+const SubscriptionListNilKind = "SubscriptionListNil"
+
 // SubscriptionList is a list of values of the 'subscription' type.
 type SubscriptionList struct {
+	href  *string
+	link  bool
 	items []*Subscription
+}
+
+// Kind returns the name of the type of the object.
+func (l *SubscriptionList) Kind() string {
+	if l == nil {
+		return SubscriptionListNilKind
+	}
+	if l.link {
+		return SubscriptionListLinkKind
+	}
+	return SubscriptionListKind
+}
+
+// Link returns true iif this is a link.
+func (l *SubscriptionList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *SubscriptionList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *SubscriptionList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/clustersmgmt/v1/user_type.go
+++ b/pkg/client/clustersmgmt/v1/user_type.go
@@ -92,9 +92,57 @@ func (o *User) GetHREF() (value string, ok bool) {
 	return
 }
 
+// UserListKind is the name of the type used to represent list of
+// objects of type 'user'.
+const UserListKind = "UserList"
+
+// UserListLinkKind is the name of the type used to represent links
+// to list of objects of type 'user'.
+const UserListLinkKind = "UserListLink"
+
+// UserNilKind is the name of the type used to nil lists of
+// objects of type 'user'.
+const UserListNilKind = "UserListNil"
+
 // UserList is a list of values of the 'user' type.
 type UserList struct {
+	href  *string
+	link  bool
 	items []*User
+}
+
+// Kind returns the name of the type of the object.
+func (l *UserList) Kind() string {
+	if l == nil {
+		return UserListNilKind
+	}
+	if l.link {
+		return UserListLinkKind
+	}
+	return UserListKind
+}
+
+// Link returns true iif this is a link.
+func (l *UserList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *UserList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *UserList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/pkg/client/clustersmgmt/v1/value_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/value_list_reader.go
@@ -46,12 +46,12 @@ func UnmarshalValueList(source interface{}) (list *ValueList, err error) {
 
 // wrap is the method used internally to convert a list of values of the
 // 'value' value to a JSON document.
-func (o *ValueList) wrap() (data valueListData, err error) {
-	if o == nil {
+func (l *ValueList) wrap() (data valueListData, err error) {
+	if l == nil {
 		return
 	}
-	data = make(valueListData, len(o.items))
-	for i, item := range o.items {
+	data = make(valueListData, len(l.items))
+	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
 			return

--- a/pkg/client/clustersmgmt/v1/version_type.go
+++ b/pkg/client/clustersmgmt/v1/version_type.go
@@ -92,9 +92,57 @@ func (o *Version) GetHREF() (value string, ok bool) {
 	return
 }
 
+// VersionListKind is the name of the type used to represent list of
+// objects of type 'version'.
+const VersionListKind = "VersionList"
+
+// VersionListLinkKind is the name of the type used to represent links
+// to list of objects of type 'version'.
+const VersionListLinkKind = "VersionListLink"
+
+// VersionNilKind is the name of the type used to nil lists of
+// objects of type 'version'.
+const VersionListNilKind = "VersionListNil"
+
 // VersionList is a list of values of the 'version' type.
 type VersionList struct {
+	href  *string
+	link  bool
 	items []*Version
+}
+
+// Kind returns the name of the type of the object.
+func (l *VersionList) Kind() string {
+	if l == nil {
+		return VersionListNilKind
+	}
+	if l.link {
+		return VersionListLinkKind
+	}
+	return VersionListKind
+}
+
+// Link returns true iif this is a link.
+func (l *VersionList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *VersionList) HREF() string {
+	if l != nil && l.href != nil {
+		return *l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *VersionList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != nil
+	if ok {
+		value = *l.href
+	}
+	return
 }
 
 // Len returns the length of the list.


### PR DESCRIPTION
This patch fixes the serialization of lists of instances of classes, for
example the list of groups of a cluster.