### PR TITLE
Fix exit code of list clusters example

### DIFF
--- a/examples/list_clusters.go
+++ b/examples/list_clusters.go
@@ -80,7 +80,4 @@ func main() {
 		}
 		page++
 	}
-
-	// Bye:
-	os.Exit(1)
 }


### PR DESCRIPTION
This patch fixes the exit code of the example that shows how to list
clusters.