### PR TITLE
Add logs collection

### DIFF
--- a/pkg/client/accountsmgmt/v1/errors.go
+++ b/pkg/client/accountsmgmt/v1/errors.go
@@ -18,5 +18,3 @@ limitations under the License.
 // your changes will be lost when the file is generated again.
 
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/accountsmgmt/v1
-
-const ()

--- a/pkg/client/clustersmgmt/v1/cluster_client.go
+++ b/pkg/client/clustersmgmt/v1/cluster_client.go
@@ -89,6 +89,13 @@ func (c *ClusterClient) Status() *ClusterStatusClient {
 	return NewClusterStatusClient(c.transport, path.Join(c.path, "status"))
 }
 
+// Logs returns the target 'logs' resource.
+//
+// Reference to the resource that manages the collection of logs of the cluster.
+func (c *ClusterClient) Logs() *LogsClient {
+	return NewLogsClient(c.transport, path.Join(c.path, "logs"))
+}
+
 // Groups returns the target 'groups' resource.
 //
 // Reference to the resource that manages the collection of groups.

--- a/pkg/client/clustersmgmt/v1/log_builder.go
+++ b/pkg/client/clustersmgmt/v1/log_builder.go
@@ -19,35 +19,35 @@ limitations under the License.
 
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
 
-// ClusterLogBuilder contains the data and logic needed to build 'cluster_log' objects.
+// LogBuilder contains the data and logic needed to build 'log' objects.
 //
-// Logs of the cluster.
-type ClusterLogBuilder struct {
+// Log of the cluster.
+type LogBuilder struct {
 	id      *string
 	href    *string
 	link    bool
 	content *string
 }
 
-// NewClusterLog creates a new builder of 'cluster_log' objects.
-func NewClusterLog() *ClusterLogBuilder {
-	return new(ClusterLogBuilder)
+// NewLog creates a new builder of 'log' objects.
+func NewLog() *LogBuilder {
+	return new(LogBuilder)
 }
 
 // ID sets the identifier of the object.
-func (b *ClusterLogBuilder) ID(value string) *ClusterLogBuilder {
+func (b *LogBuilder) ID(value string) *LogBuilder {
 	b.id = &value
 	return b
 }
 
 // HREF sets the link to the object.
-func (b *ClusterLogBuilder) HREF(value string) *ClusterLogBuilder {
+func (b *LogBuilder) HREF(value string) *LogBuilder {
 	b.href = &value
 	return b
 }
 
 // Link sets the flag that indicates if this is a link.
-func (b *ClusterLogBuilder) Link(value bool) *ClusterLogBuilder {
+func (b *LogBuilder) Link(value bool) *LogBuilder {
 	b.link = value
 	return b
 }
@@ -56,14 +56,14 @@ func (b *ClusterLogBuilder) Link(value bool) *ClusterLogBuilder {
 // to the given value.
 //
 //
-func (b *ClusterLogBuilder) Content(value string) *ClusterLogBuilder {
+func (b *LogBuilder) Content(value string) *LogBuilder {
 	b.content = &value
 	return b
 }
 
-// Build creates a 'cluster_log' object using the configuration stored in the builder.
-func (b *ClusterLogBuilder) Build() (object *ClusterLog, err error) {
-	object = new(ClusterLog)
+// Build creates a 'log' object using the configuration stored in the builder.
+func (b *LogBuilder) Build() (object *Log, err error) {
+	object = new(Log)
 	object.id = b.id
 	object.href = b.href
 	object.link = b.link

--- a/pkg/client/clustersmgmt/v1/log_client.go
+++ b/pkg/client/clustersmgmt/v1/log_client.go
@@ -1,0 +1,183 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	time "time"
+
+	"github.com/openshift-online/uhc-sdk-go/pkg/client/errors"
+	"github.com/openshift-online/uhc-sdk-go/pkg/client/helpers"
+)
+
+// LogClient is the client of the 'log' resource.
+//
+// Manages a specific log.
+type LogClient struct {
+	transport http.RoundTripper
+	path      string
+}
+
+// NewLogClient creates a new client for the 'log'
+// resource using the given transport to sned the requests and receive the
+// responses.
+func NewLogClient(transport http.RoundTripper, path string) *LogClient {
+	client := new(LogClient)
+	client.transport = transport
+	client.path = path
+	return client
+}
+
+// Get creates a request for the 'get' method.
+//
+// Retrieves the details of the log.
+func (c *LogClient) Get() *LogGetRequest {
+	request := new(LogGetRequest)
+	request.transport = c.transport
+	request.path = c.path
+	return request
+}
+
+// LogGetRequest is the request for the 'get' method.
+type LogGetRequest struct {
+	transport http.RoundTripper
+	path      string
+	context   context.Context
+	cancel    context.CancelFunc
+	query     url.Values
+	header    http.Header
+}
+
+// Context sets the context that will be used to send the request.
+func (r *LogGetRequest) Context(value context.Context) *LogGetRequest {
+	r.context = value
+	return r
+}
+
+// Timeout sets a timeout for the completete request.
+func (r *LogGetRequest) Timeout(value time.Duration) *LogGetRequest {
+	helpers.SetTimeout(&r.context, &r.cancel, value)
+	return r
+}
+
+// Deadline sets a deadline for the completete request.
+func (r *LogGetRequest) Deadline(value time.Time) *LogGetRequest {
+	helpers.SetDeadline(&r.context, &r.cancel, value)
+	return r
+}
+
+// Parameter adds a query parameter.
+func (r *LogGetRequest) Parameter(name string, value interface{}) *LogGetRequest {
+	helpers.AddValue(&r.query, name, value)
+	return r
+}
+
+// Header adds a request header.
+func (r *LogGetRequest) Header(name string, value interface{}) *LogGetRequest {
+	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Send sends this request, waits for the response, and returns it.
+func (r *LogGetRequest) Send() (result *LogGetResponse, err error) {
+	query := helpers.CopyQuery(r.query)
+	header := helpers.CopyHeader(r.header)
+	uri := &url.URL{
+		Path:     r.path,
+		RawQuery: query.Encode(),
+	}
+	request := &http.Request{
+		Method: http.MethodGet,
+		URL:    uri,
+		Header: header,
+	}
+	response, err := r.transport.RoundTrip(request)
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+	result = new(LogGetResponse)
+	result.status = response.StatusCode
+	result.header = response.Header
+	if result.status >= 400 {
+		result.err, err = errors.UnmarshalError(response.Body)
+		if err != nil {
+			return
+		}
+		err = result.err
+		return
+	}
+	err = result.unmarshal(response.Body)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// LogGetResponse is the response for the 'get' method.
+type LogGetResponse struct {
+	status int
+	header http.Header
+	err    *errors.Error
+	body   *Log
+}
+
+// Status returns the response status code.
+func (r *LogGetResponse) Status() int {
+	return r.status
+}
+
+// Header returns header of the response.
+func (r *LogGetResponse) Header() http.Header {
+	return r.header
+}
+
+// Error returns the response error.
+func (r *LogGetResponse) Error() *errors.Error {
+	return r.err
+}
+
+// Body returns the value of the 'body' parameter.
+//
+//
+func (r *LogGetResponse) Body() *Log {
+	return r.body
+}
+
+// unmarshal is the method used internally to unmarshal responses to the
+// 'get' method.
+func (r *LogGetResponse) unmarshal(reader io.Reader) error {
+	var err error
+	decoder := json.NewDecoder(reader)
+	data := new(logData)
+	err = decoder.Decode(data)
+	if err != nil {
+		return err
+	}
+	r.body, err = data.unwrap()
+	if err != nil {
+		return err
+	}
+	return err
+}

--- a/pkg/client/clustersmgmt/v1/log_list_builder.go
+++ b/pkg/client/clustersmgmt/v1/log_list_builder.go
@@ -19,35 +19,35 @@ limitations under the License.
 
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
 
-// ClusterLogListBuilder contains the data and logic needed to build
-// 'cluster_log' objects.
-type ClusterLogListBuilder struct {
-	items []*ClusterLogBuilder
+// LogListBuilder contains the data and logic needed to build
+// 'log' objects.
+type LogListBuilder struct {
+	items []*LogBuilder
 }
 
-// NewClusterLogList creates a new builder of 'cluster_log' objects.
-func NewClusterLogList() *ClusterLogListBuilder {
-	return new(ClusterLogListBuilder)
+// NewLogList creates a new builder of 'log' objects.
+func NewLogList() *LogListBuilder {
+	return new(LogListBuilder)
 }
 
 // Items sets the items of the list.
-func (b *ClusterLogListBuilder) Items(values ...*ClusterLogBuilder) *ClusterLogListBuilder {
-	b.items = make([]*ClusterLogBuilder, len(values))
+func (b *LogListBuilder) Items(values ...*LogBuilder) *LogListBuilder {
+	b.items = make([]*LogBuilder, len(values))
 	copy(b.items, values)
 	return b
 }
 
-// Build creates a list of 'cluster_log' objects using the
+// Build creates a list of 'log' objects using the
 // configuration stored in the builder.
-func (b *ClusterLogListBuilder) Build() (list *ClusterLogList, err error) {
-	items := make([]*ClusterLog, len(b.items))
+func (b *LogListBuilder) Build() (list *LogList, err error) {
+	items := make([]*Log, len(b.items))
 	for i, item := range b.items {
 		items[i], err = item.Build()
 		if err != nil {
 			return
 		}
 	}
-	list = new(ClusterLogList)
+	list = new(LogList)
 	list.items = items
 	return
 }

--- a/pkg/client/clustersmgmt/v1/log_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/log_list_reader.go
@@ -25,19 +25,19 @@ import (
 	"github.com/openshift-online/uhc-sdk-go/pkg/client/helpers"
 )
 
-// clusterLogListData is type used internally to marshal and unmarshal lists of objects
-// of type 'cluster_log'.
-type clusterLogListData []*clusterLogData
+// logListData is type used internally to marshal and unmarshal lists of objects
+// of type 'log'.
+type logListData []*logData
 
-// UnmarshalClusterLogList reads a list of values of the 'cluster_log'
+// UnmarshalLogList reads a list of values of the 'log'
 // from the given source, which can be a slice of bytes, a string, an io.Reader or a
 // json.Decoder.
-func UnmarshalClusterLogList(source interface{}) (list *ClusterLogList, err error) {
+func UnmarshalLogList(source interface{}) (list *LogList, err error) {
 	decoder, err := helpers.NewDecoder(source)
 	if err != nil {
 		return
 	}
-	var data clusterLogListData
+	var data logListData
 	err = decoder.Decode(&data)
 	if err != nil {
 		return
@@ -47,12 +47,12 @@ func UnmarshalClusterLogList(source interface{}) (list *ClusterLogList, err erro
 }
 
 // wrap is the method used internally to convert a list of values of the
-// 'cluster_log' value to a JSON document.
-func (l *ClusterLogList) wrap() (data clusterLogListData, err error) {
+// 'log' value to a JSON document.
+func (l *LogList) wrap() (data logListData, err error) {
 	if l == nil {
 		return
 	}
-	data = make(clusterLogListData, len(l.items))
+	data = make(logListData, len(l.items))
 	for i, item := range l.items {
 		data[i], err = item.wrap()
 		if err != nil {
@@ -63,83 +63,83 @@ func (l *ClusterLogList) wrap() (data clusterLogListData, err error) {
 }
 
 // unwrap is the function used internally to convert the JSON unmarshalled data to a
-// list of values of the 'cluster_log' type.
-func (d clusterLogListData) unwrap() (list *ClusterLogList, err error) {
+// list of values of the 'log' type.
+func (d logListData) unwrap() (list *LogList, err error) {
 	if d == nil {
 		return
 	}
-	items := make([]*ClusterLog, len(d))
+	items := make([]*Log, len(d))
 	for i, item := range d {
 		items[i], err = item.unwrap()
 		if err != nil {
 			return
 		}
 	}
-	list = new(ClusterLogList)
+	list = new(LogList)
 	list.items = items
 	return
 }
 
-// clusterLogListLinkData is type used internally to marshal and unmarshal links
-// to lists of objects of type 'cluster_log'.
-type clusterLogListLinkData struct {
-	Kind  *string           "json:\"kind,omitempty\""
-	HREF  *string           "json:\"href,omitempty\""
-	Items []*clusterLogData "json:\"items,omitempty\""
+// logListLinkData is type used internally to marshal and unmarshal links
+// to lists of objects of type 'log'.
+type logListLinkData struct {
+	Kind  *string    "json:\"kind,omitempty\""
+	HREF  *string    "json:\"href,omitempty\""
+	Items []*logData "json:\"items,omitempty\""
 }
 
 // wrapLink is the method used internally to convert a list of values of the
-// 'cluster_log' value to a link.
-func (l *ClusterLogList) wrapLink() (data *clusterLogListLinkData, err error) {
+// 'log' value to a link.
+func (l *LogList) wrapLink() (data *logListLinkData, err error) {
 	if l == nil {
 		return
 	}
-	items := make([]*clusterLogData, len(l.items))
+	items := make([]*logData, len(l.items))
 	for i, item := range l.items {
 		items[i], err = item.wrap()
 		if err != nil {
 			return
 		}
 	}
-	data = new(clusterLogListLinkData)
+	data = new(logListLinkData)
 	data.Items = items
 	data.HREF = l.href
 	data.Kind = new(string)
 	if l.link {
-		*data.Kind = ClusterLogListLinkKind
+		*data.Kind = LogListLinkKind
 	} else {
-		*data.Kind = ClusterLogListKind
+		*data.Kind = LogListKind
 	}
 	return
 }
 
 // unwrapLink is the function used internally to convert a JSON link to a list
-// of values of the 'cluster_log' type to a list.
-func (d *clusterLogListLinkData) unwrapLink() (list *ClusterLogList, err error) {
+// of values of the 'log' type to a list.
+func (d *logListLinkData) unwrapLink() (list *LogList, err error) {
 	if d == nil {
 		return
 	}
-	items := make([]*ClusterLog, len(d.Items))
+	items := make([]*Log, len(d.Items))
 	for i, item := range d.Items {
 		items[i], err = item.unwrap()
 		if err != nil {
 			return
 		}
 	}
-	list = new(ClusterLogList)
+	list = new(LogList)
 	list.items = items
 	list.href = d.HREF
 	if d.Kind != nil {
 		switch *d.Kind {
-		case ClusterLogListKind:
+		case LogListKind:
 			list.link = false
-		case ClusterLogListLinkKind:
+		case LogListLinkKind:
 			list.link = true
 		default:
 			err = fmt.Errorf(
 				"expected kind '%s' or '%s' but got '%s'",
-				ClusterLogListKind,
-				ClusterLogListLinkKind,
+				LogListKind,
+				LogListLinkKind,
 				*d.Kind,
 			)
 			return

--- a/pkg/client/clustersmgmt/v1/log_reader.go
+++ b/pkg/client/clustersmgmt/v1/log_reader.go
@@ -25,18 +25,18 @@ import (
 	"github.com/openshift-online/uhc-sdk-go/pkg/client/helpers"
 )
 
-// clusterLogData is the data structure used internally to marshal and unmarshal
-// objects of type 'cluster_log'.
-type clusterLogData struct {
+// logData is the data structure used internally to marshal and unmarshal
+// objects of type 'log'.
+type logData struct {
 	Kind    *string "json:\"kind,omitempty\""
 	ID      *string "json:\"id,omitempty\""
 	HREF    *string "json:\"href,omitempty\""
 	Content *string "json:\"content,omitempty\""
 }
 
-// MarshalClusterLog writes a value of the 'cluster_log' to the given target,
+// MarshalLog writes a value of the 'log' to the given target,
 // which can be a writer or a JSON encoder.
-func MarshalClusterLog(object *ClusterLog, target interface{}) error {
+func MarshalLog(object *Log, target interface{}) error {
 	encoder, err := helpers.NewEncoder(target)
 	if err != nil {
 		return err
@@ -48,33 +48,33 @@ func MarshalClusterLog(object *ClusterLog, target interface{}) error {
 	return encoder.Encode(data)
 }
 
-// wrap is the method used internally to convert a value of the 'cluster_log'
+// wrap is the method used internally to convert a value of the 'log'
 // value to a JSON document.
-func (o *ClusterLog) wrap() (data *clusterLogData, err error) {
+func (o *Log) wrap() (data *logData, err error) {
 	if o == nil {
 		return
 	}
-	data = new(clusterLogData)
+	data = new(logData)
 	data.ID = o.id
 	data.HREF = o.href
 	data.Kind = new(string)
 	if o.link {
-		*data.Kind = ClusterLogLinkKind
+		*data.Kind = LogLinkKind
 	} else {
-		*data.Kind = ClusterLogKind
+		*data.Kind = LogKind
 	}
 	data.Content = o.content
 	return
 }
 
-// UnmarshalClusterLog reads a value of the 'cluster_log' type from the given
+// UnmarshalLog reads a value of the 'log' type from the given
 // source, which can be an slice of bytes, a string, a reader or a JSON decoder.
-func UnmarshalClusterLog(source interface{}) (object *ClusterLog, err error) {
+func UnmarshalLog(source interface{}) (object *Log, err error) {
 	decoder, err := helpers.NewDecoder(source)
 	if err != nil {
 		return
 	}
-	data := new(clusterLogData)
+	data := new(logData)
 	err = decoder.Decode(data)
 	if err != nil {
 		return
@@ -84,25 +84,25 @@ func UnmarshalClusterLog(source interface{}) (object *ClusterLog, err error) {
 }
 
 // unwrap is the function used internally to convert the JSON unmarshalled data to a
-// value of the 'cluster_log' type.
-func (d *clusterLogData) unwrap() (object *ClusterLog, err error) {
+// value of the 'log' type.
+func (d *logData) unwrap() (object *Log, err error) {
 	if d == nil {
 		return
 	}
-	object = new(ClusterLog)
+	object = new(Log)
 	object.id = d.ID
 	object.href = d.HREF
 	if d.Kind != nil {
 		switch *d.Kind {
-		case ClusterLogKind:
+		case LogKind:
 			object.link = false
-		case ClusterLogLinkKind:
+		case LogLinkKind:
 			object.link = true
 		default:
 			err = fmt.Errorf(
 				"expected kind '%s' or '%s' but got '%s'",
-				ClusterLogKind,
-				ClusterLogLinkKind,
+				LogKind,
+				LogLinkKind,
 				*d.Kind,
 			)
 			return

--- a/pkg/client/clustersmgmt/v1/log_type.go
+++ b/pkg/client/clustersmgmt/v1/log_type.go
@@ -19,22 +19,22 @@ limitations under the License.
 
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
 
-// ClusterLogKind is the name of the type used to represent objects
-// of type 'cluster_log'.
-const ClusterLogKind = "ClusterLog"
+// LogKind is the name of the type used to represent objects
+// of type 'log'.
+const LogKind = "Log"
 
-// ClusterLogLinkKind is the name of the type used to represent links
-// to objects of type 'cluster_log'.
-const ClusterLogLinkKind = "ClusterLogLink"
+// LogLinkKind is the name of the type used to represent links
+// to objects of type 'log'.
+const LogLinkKind = "LogLink"
 
-// ClusterLogNilKind is the name of the type used to nil references
-// to objects of type 'cluster_log'.
-const ClusterLogNilKind = "ClusterLogNil"
+// LogNilKind is the name of the type used to nil references
+// to objects of type 'log'.
+const LogNilKind = "LogNil"
 
-// ClusterLog represents the values of the 'cluster_log' type.
+// Log represents the values of the 'log' type.
 //
-// Logs of the cluster.
-type ClusterLog struct {
+// Log of the cluster.
+type Log struct {
 	id      *string
 	href    *string
 	link    bool
@@ -42,18 +42,18 @@ type ClusterLog struct {
 }
 
 // Kind returns the name of the type of the object.
-func (o *ClusterLog) Kind() string {
+func (o *Log) Kind() string {
 	if o == nil {
-		return ClusterLogNilKind
+		return LogNilKind
 	}
 	if o.link {
-		return ClusterLogLinkKind
+		return LogLinkKind
 	}
-	return ClusterLogKind
+	return LogKind
 }
 
 // ID returns the identifier of the object.
-func (o *ClusterLog) ID() string {
+func (o *Log) ID() string {
 	if o != nil && o.id != nil {
 		return *o.id
 	}
@@ -62,7 +62,7 @@ func (o *ClusterLog) ID() string {
 
 // GetID returns the identifier of the object and a flag indicating if the
 // identifier has a value.
-func (o *ClusterLog) GetID() (value string, ok bool) {
+func (o *Log) GetID() (value string, ok bool) {
 	ok = o != nil && o.id != nil
 	if ok {
 		value = *o.id
@@ -71,12 +71,12 @@ func (o *ClusterLog) GetID() (value string, ok bool) {
 }
 
 // Link returns true iif this is a link.
-func (o *ClusterLog) Link() bool {
+func (o *Log) Link() bool {
 	return o != nil && o.link
 }
 
 // HREF returns the link to the object.
-func (o *ClusterLog) HREF() string {
+func (o *Log) HREF() string {
 	if o != nil && o.href != nil {
 		return *o.href
 	}
@@ -85,7 +85,7 @@ func (o *ClusterLog) HREF() string {
 
 // GetHREF returns the link of the object and a flag indicating if the
 // link has a value.
-func (o *ClusterLog) GetHREF() (value string, ok bool) {
+func (o *Log) GetHREF() (value string, ok bool) {
 	ok = o != nil && o.href != nil
 	if ok {
 		value = *o.href
@@ -97,7 +97,7 @@ func (o *ClusterLog) GetHREF() (value string, ok bool) {
 // the zero value of the type if the attribute doesn't have a value.
 //
 // Content of the log.
-func (o *ClusterLog) Content() string {
+func (o *Log) Content() string {
 	if o != nil && o.content != nil {
 		return *o.content
 	}
@@ -108,7 +108,7 @@ func (o *ClusterLog) Content() string {
 // a flag indicating if the attribute has a value.
 //
 // Content of the log.
-func (o *ClusterLog) GetContent() (value string, ok bool) {
+func (o *Log) GetContent() (value string, ok bool) {
 	ok = o != nil && o.content != nil
 	if ok {
 		value = *o.content
@@ -116,43 +116,43 @@ func (o *ClusterLog) GetContent() (value string, ok bool) {
 	return
 }
 
-// ClusterLogListKind is the name of the type used to represent list of
-// objects of type 'cluster_log'.
-const ClusterLogListKind = "ClusterLogList"
+// LogListKind is the name of the type used to represent list of
+// objects of type 'log'.
+const LogListKind = "LogList"
 
-// ClusterLogListLinkKind is the name of the type used to represent links
-// to list of objects of type 'cluster_log'.
-const ClusterLogListLinkKind = "ClusterLogListLink"
+// LogListLinkKind is the name of the type used to represent links
+// to list of objects of type 'log'.
+const LogListLinkKind = "LogListLink"
 
-// ClusterLogNilKind is the name of the type used to nil lists of
-// objects of type 'cluster_log'.
-const ClusterLogListNilKind = "ClusterLogListNil"
+// LogNilKind is the name of the type used to nil lists of
+// objects of type 'log'.
+const LogListNilKind = "LogListNil"
 
-// ClusterLogList is a list of values of the 'cluster_log' type.
-type ClusterLogList struct {
+// LogList is a list of values of the 'log' type.
+type LogList struct {
 	href  *string
 	link  bool
-	items []*ClusterLog
+	items []*Log
 }
 
 // Kind returns the name of the type of the object.
-func (l *ClusterLogList) Kind() string {
+func (l *LogList) Kind() string {
 	if l == nil {
-		return ClusterLogListNilKind
+		return LogListNilKind
 	}
 	if l.link {
-		return ClusterLogListLinkKind
+		return LogListLinkKind
 	}
-	return ClusterLogListKind
+	return LogListKind
 }
 
 // Link returns true iif this is a link.
-func (l *ClusterLogList) Link() bool {
+func (l *LogList) Link() bool {
 	return l != nil && l.link
 }
 
 // HREF returns the link to the list.
-func (l *ClusterLogList) HREF() string {
+func (l *LogList) HREF() string {
 	if l != nil && l.href != nil {
 		return *l.href
 	}
@@ -161,7 +161,7 @@ func (l *ClusterLogList) HREF() string {
 
 // GetHREF returns the link of the list and a flag indicating if the
 // link has a value.
-func (l *ClusterLogList) GetHREF() (value string, ok bool) {
+func (l *LogList) GetHREF() (value string, ok bool) {
 	ok = l != nil && l.href != nil
 	if ok {
 		value = *l.href
@@ -170,7 +170,7 @@ func (l *ClusterLogList) GetHREF() (value string, ok bool) {
 }
 
 // Len returns the length of the list.
-func (l *ClusterLogList) Len() int {
+func (l *LogList) Len() int {
 	if l == nil {
 		return 0
 	}
@@ -183,12 +183,12 @@ func (l *ClusterLogList) Len() int {
 //
 // If you don't need to modify the returned slice consider using the Each or Range
 // functions, as they don't need to allocate a new slice.
-func (l *ClusterLogList) Slice() []*ClusterLog {
-	var slice []*ClusterLog
+func (l *LogList) Slice() []*Log {
+	var slice []*Log
 	if l == nil {
-		slice = make([]*ClusterLog, 0)
+		slice = make([]*Log, 0)
 	} else {
-		slice = make([]*ClusterLog, len(l.items))
+		slice = make([]*Log, len(l.items))
 		copy(slice, l.items)
 	}
 	return slice
@@ -197,7 +197,7 @@ func (l *ClusterLogList) Slice() []*ClusterLog {
 // Each runs the given function for each item of the list, in order. If the function
 // returns false the iteration stops, otherwise it continues till all the elements
 // of the list have been processed.
-func (l *ClusterLogList) Each(f func(item *ClusterLog) bool) {
+func (l *LogList) Each(f func(item *Log) bool) {
 	if l == nil {
 		return
 	}
@@ -211,7 +211,7 @@ func (l *ClusterLogList) Each(f func(item *ClusterLog) bool) {
 // Range runs the given function for each index and item of the list, in order. If
 // the function returns false the iteration stops, otherwise it continues till all
 // the elements of the list have been processed.
-func (l *ClusterLogList) Range(f func(index int, item *ClusterLog) bool) {
+func (l *LogList) Range(f func(index int, item *Log) bool) {
 	if l == nil {
 		return
 	}

--- a/pkg/client/clustersmgmt/v1/logs_client.go
+++ b/pkg/client/clustersmgmt/v1/logs_client.go
@@ -1,0 +1,236 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	time "time"
+
+	"github.com/openshift-online/uhc-sdk-go/pkg/client/errors"
+	"github.com/openshift-online/uhc-sdk-go/pkg/client/helpers"
+)
+
+// LogsClient is the client of the 'logs' resource.
+//
+// Manages a collection of logs.
+type LogsClient struct {
+	transport http.RoundTripper
+	path      string
+}
+
+// NewLogsClient creates a new client for the 'logs'
+// resource using the given transport to sned the requests and receive the
+// responses.
+func NewLogsClient(transport http.RoundTripper, path string) *LogsClient {
+	client := new(LogsClient)
+	client.transport = transport
+	client.path = path
+	return client
+}
+
+// List creates a request for the 'list' method.
+//
+// Retrieves the list of clusters.
+func (c *LogsClient) List() *LogsListRequest {
+	request := new(LogsListRequest)
+	request.transport = c.transport
+	request.path = c.path
+	return request
+}
+
+// Log returns the target 'log' resource for the given identifier.
+//
+// Retursn a reference to the service that manages an specific log.
+func (c *LogsClient) Log(id string) *LogClient {
+	return NewLogClient(c.transport, path.Join(c.path, id))
+}
+
+// LogsListRequest is the request for the 'list' method.
+type LogsListRequest struct {
+	transport http.RoundTripper
+	path      string
+	context   context.Context
+	cancel    context.CancelFunc
+	query     url.Values
+	header    http.Header
+}
+
+// Context sets the context that will be used to send the request.
+func (r *LogsListRequest) Context(value context.Context) *LogsListRequest {
+	r.context = value
+	return r
+}
+
+// Timeout sets a timeout for the completete request.
+func (r *LogsListRequest) Timeout(value time.Duration) *LogsListRequest {
+	helpers.SetTimeout(&r.context, &r.cancel, value)
+	return r
+}
+
+// Deadline sets a deadline for the completete request.
+func (r *LogsListRequest) Deadline(value time.Time) *LogsListRequest {
+	helpers.SetDeadline(&r.context, &r.cancel, value)
+	return r
+}
+
+// Parameter adds a query parameter.
+func (r *LogsListRequest) Parameter(name string, value interface{}) *LogsListRequest {
+	helpers.AddValue(&r.query, name, value)
+	return r
+}
+
+// Header adds a request header.
+func (r *LogsListRequest) Header(name string, value interface{}) *LogsListRequest {
+	helpers.AddHeader(&r.header, name, value)
+	return r
+}
+
+// Send sends this request, waits for the response, and returns it.
+func (r *LogsListRequest) Send() (result *LogsListResponse, err error) {
+	query := helpers.CopyQuery(r.query)
+	header := helpers.CopyHeader(r.header)
+	uri := &url.URL{
+		Path:     r.path,
+		RawQuery: query.Encode(),
+	}
+	request := &http.Request{
+		Method: http.MethodGet,
+		URL:    uri,
+		Header: header,
+	}
+	response, err := r.transport.RoundTrip(request)
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+	result = new(LogsListResponse)
+	result.status = response.StatusCode
+	result.header = response.Header
+	if result.status >= 400 {
+		result.err, err = errors.UnmarshalError(response.Body)
+		if err != nil {
+			return
+		}
+		err = result.err
+		return
+	}
+	err = result.unmarshal(response.Body)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// LogsListResponse is the response for the 'list' method.
+type LogsListResponse struct {
+	status int
+	header http.Header
+	err    *errors.Error
+	page   *int
+	size   *int
+	total  *int
+	items  *LogList
+}
+
+// Status returns the response status code.
+func (r *LogsListResponse) Status() int {
+	return r.status
+}
+
+// Header returns header of the response.
+func (r *LogsListResponse) Header() http.Header {
+	return r.header
+}
+
+// Error returns the response error.
+func (r *LogsListResponse) Error() *errors.Error {
+	return r.err
+}
+
+// Page returns the value of the 'page' parameter.
+//
+// Index of the requested page, where one corresponds to the first page.
+func (r *LogsListResponse) Page() int {
+	if r.page != nil {
+		return *r.page
+	}
+	return 0
+}
+
+// Size returns the value of the 'size' parameter.
+//
+// Number of items contained in the returned page.
+func (r *LogsListResponse) Size() int {
+	if r.size != nil {
+		return *r.size
+	}
+	return 0
+}
+
+// Total returns the value of the 'total' parameter.
+//
+// Total number of items of the collection.
+func (r *LogsListResponse) Total() int {
+	if r.total != nil {
+		return *r.total
+	}
+	return 0
+}
+
+// Items returns the value of the 'items' parameter.
+//
+// Retrieved list of logs.
+func (r *LogsListResponse) Items() *LogList {
+	return r.items
+}
+
+// unmarshal is the method used internally to unmarshal responses to the
+// 'list' method.
+func (r *LogsListResponse) unmarshal(reader io.Reader) error {
+	var err error
+	decoder := json.NewDecoder(reader)
+	data := new(logsListResponseData)
+	err = decoder.Decode(data)
+	if err != nil {
+		return err
+	}
+	r.page = data.Page
+	r.size = data.Size
+	r.total = data.Total
+	r.items, err = data.Items.unwrap()
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+// logsListResponseData is the structure used internally to unmarshal
+// the response of the 'list' method.
+type logsListResponseData struct {
+	Page  *int        "json:\"page,omitempty\""
+	Size  *int        "json:\"size,omitempty\""
+	Total *int        "json:\"total,omitempty\""
+	Items logListData "json:\"items,omitempty\""
+}


### PR DESCRIPTION
This patch adds the clients for the resource that manages the collection
of logs of a cluster, and an example explaining how to use it.