### PR TITLE
Fix example in documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -241,7 +241,7 @@ name, ok := cluster.GetName()
 if !ok {
 	fmt.Printf("Cluster has no name\n")
 } else {
-	fmt.Printf("Cluster name is '%s'\n")
+	fmt.Printf("Cluster name is '%s'\n", name)
 }
 ----
 


### PR DESCRIPTION
This patch fixes a missing argument in a `Printf` call in an example
inside the `README.adoc` file.