### PR TITLE
Move metrics to `metrics` attribute

### DIFF
--- a/examples/get_cluster_metrics.go
+++ b/examples/get_cluster_metrics.go
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This example shows how to retrieve the basic metrics of a cluster.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/openshift-online/uhc-sdk-go/pkg/client"
+	"github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1"
+)
+
+func main() {
+	// Create a logger that has the debug level enabled:
+	logger, err := client.NewGoLoggerBuilder().
+		Debug(true).
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build logger: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Create the connection, and remember to close it:
+	token := os.Getenv("UHC_TOKEN")
+	connection, err := client.NewConnectionBuilder().
+		Logger(logger).
+		Tokens(token).
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build client: %v\n", err)
+		os.Exit(1)
+	}
+	defer connection.Close()
+
+	// Get the client for the resource that manages the collection of clusters:
+	collection := connection.ClustersMgmt().V1().Clusters()
+
+	// Get the client for the resource that manages the the cluster that we are looking for.
+	// Note that this will not send any request to the server yet, so it will succeed even if
+	// that cluster doesn't exist.
+	resource := collection.Cluster("1Jam7Ejgpm7AbZshbgaA9TsM1SQ")
+
+	// Send the request to retrieve the details of the cluster:
+	response, err := resource.Get().Send()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't retrieve cluster details: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Print the metrics:
+	cluster := response.Body()
+	metrics := cluster.Metrics()
+	cpu := metrics.CPU()
+	memory := metrics.Memory()
+	fmt.Printf("CPU total: %s\n", valueString(cpu.Total()))
+	fmt.Printf("CPU used: %s\n", valueString(cpu.Used()))
+	fmt.Printf("Memory total: %s\n", valueString(memory.Total()))
+	fmt.Printf("CPU used: %s\n", valueString(memory.Used()))
+}
+
+// valueString converts an API value to an string, taking into account that it may be nil, and that
+// it may not have an unit.
+func valueString(v *v1.Value) string {
+	if v == nil {
+		return "N/A"
+	}
+	value, ok := v.GetValue()
+	if !ok {
+		return "N/A"
+	}
+	unit, ok := v.GetUnit()
+	if !ok {
+		return fmt.Sprintf("%.2f", value)
+	}
+	return fmt.Sprintf("%.2f %s", value, unit)
+}

--- a/pkg/client/accountsmgmt/v1/access_token_type.go
+++ b/pkg/client/accountsmgmt/v1/access_token_type.go
@@ -25,6 +25,11 @@ package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/accountsmgmt/v1
 type AccessToken struct {
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AccessToken) Empty() bool {
+	return o == nil || (true)
+}
+
 // AccessTokenList is a list of values of the 'access_token' type.
 type AccessTokenList struct {
 	items []*AccessToken
@@ -36,6 +41,11 @@ func (l *AccessTokenList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *AccessTokenList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/accountsmgmt/v1/account_type.go
+++ b/pkg/client/accountsmgmt/v1/account_type.go
@@ -98,6 +98,18 @@ func (o *Account) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *Account) Empty() bool {
+	return o == nil || (o.id == nil &&
+		o.name == nil &&
+		o.username == nil &&
+		o.email == nil &&
+		o.banned == nil &&
+		o.banDescription == nil &&
+		o.organization == nil &&
+		true)
+}
+
 // Name returns the value of the 'name' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -295,6 +307,11 @@ func (l *AccountList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *AccountList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/accountsmgmt/v1/cluster_authorization_request_type.go
+++ b/pkg/client/accountsmgmt/v1/cluster_authorization_request_type.go
@@ -32,6 +32,18 @@ type ClusterAuthorizationRequest struct {
 	resources        *ReservedResourceList
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ClusterAuthorizationRequest) Empty() bool {
+	return o == nil || (o.clusterID == nil &&
+		o.accountUsername == nil &&
+		o.managed == nil &&
+		o.reserve == nil &&
+		o.byoc == nil &&
+		o.availabilityZone == nil &&
+		o.resources.Empty() &&
+		true)
+}
+
 // ClusterID returns the value of the 'cluster_ID' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -204,6 +216,11 @@ func (l *ClusterAuthorizationRequestList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *ClusterAuthorizationRequestList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/accountsmgmt/v1/cluster_authorization_response_type.go
+++ b/pkg/client/accountsmgmt/v1/cluster_authorization_response_type.go
@@ -28,6 +28,14 @@ type ClusterAuthorizationResponse struct {
 	subscription    *Subscription
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ClusterAuthorizationResponse) Empty() bool {
+	return o == nil || (o.allowed == nil &&
+		o.excessResources.Empty() &&
+		o.subscription == nil &&
+		true)
+}
+
 // Allowed returns the value of the 'allowed' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -108,6 +116,11 @@ func (l *ClusterAuthorizationResponseList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *ClusterAuthorizationResponseList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/accountsmgmt/v1/cluster_registration_request_type.go
+++ b/pkg/client/accountsmgmt/v1/cluster_registration_request_type.go
@@ -27,6 +27,13 @@ type ClusterRegistrationRequest struct {
 	authorizationToken *string
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ClusterRegistrationRequest) Empty() bool {
+	return o == nil || (o.clusterID == nil &&
+		o.authorizationToken == nil &&
+		true)
+}
+
 // ClusterID returns the value of the 'cluster_ID' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -84,6 +91,11 @@ func (l *ClusterRegistrationRequestList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *ClusterRegistrationRequestList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/accountsmgmt/v1/cluster_registration_response_type.go
+++ b/pkg/client/accountsmgmt/v1/cluster_registration_response_type.go
@@ -33,6 +33,15 @@ type ClusterRegistrationResponse struct {
 	expiresAt          *time.Time
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ClusterRegistrationResponse) Empty() bool {
+	return o == nil || (o.clusterID == nil &&
+		o.authorizationToken == nil &&
+		o.accountID == nil &&
+		o.expiresAt == nil &&
+		true)
+}
+
 // ClusterID returns the value of the 'cluster_ID' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -136,6 +145,11 @@ func (l *ClusterRegistrationResponseList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *ClusterRegistrationResponseList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/accountsmgmt/v1/organization_type.go
+++ b/pkg/client/accountsmgmt/v1/organization_type.go
@@ -93,6 +93,13 @@ func (o *Organization) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *Organization) Empty() bool {
+	return o == nil || (o.id == nil &&
+		o.name == nil &&
+		true)
+}
+
 // Name returns the value of the 'name' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -175,6 +182,11 @@ func (l *OrganizationList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *OrganizationList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/accountsmgmt/v1/permission_type.go
+++ b/pkg/client/accountsmgmt/v1/permission_type.go
@@ -95,6 +95,15 @@ func (o *Permission) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *Permission) Empty() bool {
+	return o == nil || (o.id == nil &&
+		o.action == nil &&
+		o.resourceType == nil &&
+		o.roleID == nil &&
+		true)
+}
+
 // Action returns the value of the 'action' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -223,6 +232,11 @@ func (l *PermissionList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *PermissionList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/accountsmgmt/v1/plan_type.go
+++ b/pkg/client/accountsmgmt/v1/plan_type.go
@@ -92,6 +92,12 @@ func (o *Plan) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *Plan) Empty() bool {
+	return o == nil || (o.id == nil &&
+		true)
+}
+
 // PlanListKind is the name of the type used to represent list of
 // objects of type 'plan'.
 const PlanListKind = "PlanList"
@@ -151,6 +157,11 @@ func (l *PlanList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *PlanList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/accountsmgmt/v1/registry_credential_type.go
+++ b/pkg/client/accountsmgmt/v1/registry_credential_type.go
@@ -96,6 +96,16 @@ func (o *RegistryCredential) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *RegistryCredential) Empty() bool {
+	return o == nil || (o.id == nil &&
+		o.username == nil &&
+		o.token == nil &&
+		o.registry == nil &&
+		o.account == nil &&
+		true)
+}
+
 // Username returns the value of the 'username' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -247,6 +257,11 @@ func (l *RegistryCredentialList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *RegistryCredentialList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/accountsmgmt/v1/registry_type.go
+++ b/pkg/client/accountsmgmt/v1/registry_type.go
@@ -98,6 +98,18 @@ func (o *Registry) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *Registry) Empty() bool {
+	return o == nil || (o.id == nil &&
+		o.name == nil &&
+		o.url == nil &&
+		o.teamName == nil &&
+		o.orgName == nil &&
+		o.type_ == nil &&
+		o.cloudAlias == nil &&
+		true)
+}
+
 // Name returns the value of the 'name' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -295,6 +307,11 @@ func (l *RegistryList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *RegistryList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/accountsmgmt/v1/reserved_resource_type.go
+++ b/pkg/client/accountsmgmt/v1/reserved_resource_type.go
@@ -30,6 +30,16 @@ type ReservedResource struct {
 	count                *int
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ReservedResource) Empty() bool {
+	return o == nil || (o.resourceName == nil &&
+		o.resourceType == nil &&
+		o.byoc == nil &&
+		o.availabilityZoneType == nil &&
+		o.count == nil &&
+		true)
+}
+
 // ResourceName returns the value of the 'resource_name' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -156,6 +166,11 @@ func (l *ReservedResourceList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *ReservedResourceList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/accountsmgmt/v1/resource_quota_type.go
+++ b/pkg/client/accountsmgmt/v1/resource_quota_type.go
@@ -100,6 +100,20 @@ func (o *ResourceQuota) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ResourceQuota) Empty() bool {
+	return o == nil || (o.id == nil &&
+		o.organizationID == nil &&
+		o.sku == nil &&
+		o.resourceName == nil &&
+		o.resourceType == nil &&
+		o.byoc == nil &&
+		o.availabilityZoneType == nil &&
+		o.allowed == nil &&
+		o.reserved == nil &&
+		true)
+}
+
 // OrganizationID returns the value of the 'organization_ID' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -343,6 +357,11 @@ func (l *ResourceQuotaList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *ResourceQuotaList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/accountsmgmt/v1/role_binding_type.go
+++ b/pkg/client/accountsmgmt/v1/role_binding_type.go
@@ -97,6 +97,17 @@ func (o *RoleBinding) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *RoleBinding) Empty() bool {
+	return o == nil || (o.id == nil &&
+		o.type_ == nil &&
+		o.subscription == nil &&
+		o.account == nil &&
+		o.organization == nil &&
+		o.role == nil &&
+		true)
+}
+
 // Type returns the value of the 'type' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -271,6 +282,11 @@ func (l *RoleBindingList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *RoleBindingList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/accountsmgmt/v1/role_type.go
+++ b/pkg/client/accountsmgmt/v1/role_type.go
@@ -94,6 +94,14 @@ func (o *Role) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *Role) Empty() bool {
+	return o == nil || (o.id == nil &&
+		o.name == nil &&
+		o.permissions.Empty() &&
+		true)
+}
+
 // Name returns the value of the 'name' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -199,6 +207,11 @@ func (l *RoleList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *RoleList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/accountsmgmt/v1/subscription_type.go
+++ b/pkg/client/accountsmgmt/v1/subscription_type.go
@@ -102,6 +102,18 @@ func (o *Subscription) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *Subscription) Empty() bool {
+	return o == nil || (o.id == nil &&
+		o.plan == nil &&
+		o.registryCredential == nil &&
+		o.clusterID == nil &&
+		o.externalClusterID == nil &&
+		o.organizationID == nil &&
+		o.lastTelemetryDate == nil &&
+		true)
+}
+
 // Plan returns the value of the 'plan' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -299,6 +311,11 @@ func (l *SubscriptionList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *SubscriptionList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/admin_credentials_type.go
+++ b/pkg/client/clustersmgmt/v1/admin_credentials_type.go
@@ -28,6 +28,13 @@ type AdminCredentials struct {
 	password *string
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AdminCredentials) Empty() bool {
+	return o == nil || (o.user == nil &&
+		o.password == nil &&
+		true)
+}
+
 // User returns the value of the 'user' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -85,6 +92,11 @@ func (l *AdminCredentialsList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *AdminCredentialsList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/aws_type.go
+++ b/pkg/client/clustersmgmt/v1/aws_type.go
@@ -27,6 +27,13 @@ type AWS struct {
 	secretAccessKey *string
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AWS) Empty() bool {
+	return o == nil || (o.accessKeyID == nil &&
+		o.secretAccessKey == nil &&
+		true)
+}
+
 // AccessKeyID returns the value of the 'access_key_ID' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -84,6 +91,11 @@ func (l *AWSList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *AWSList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/cloud_provider_type.go
+++ b/pkg/client/clustersmgmt/v1/cloud_provider_type.go
@@ -27,6 +27,13 @@ type CloudProvider struct {
 	displayName *string
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *CloudProvider) Empty() bool {
+	return o == nil || (o.name == nil &&
+		o.displayName == nil &&
+		true)
+}
+
 // Name returns the value of the 'name' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -86,6 +93,11 @@ func (l *CloudProviderList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *CloudProviderList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/cloud_region_type.go
+++ b/pkg/client/clustersmgmt/v1/cloud_region_type.go
@@ -95,6 +95,15 @@ func (o *CloudRegion) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *CloudRegion) Empty() bool {
+	return o == nil || (o.id == nil &&
+		o.name == nil &&
+		o.displayName == nil &&
+		o.cloudProvider == nil &&
+		true)
+}
+
 // Name returns the value of the 'name' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -229,6 +238,11 @@ func (l *CloudRegionList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *CloudRegionList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/cluster_api_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_api_type.go
@@ -26,6 +26,12 @@ type ClusterAPI struct {
 	url *string
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ClusterAPI) Empty() bool {
+	return o == nil || (o.url == nil &&
+		true)
+}
+
 // URL returns the value of the 'URL' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -60,6 +66,11 @@ func (l *ClusterAPIList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *ClusterAPIList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/cluster_builder.go
+++ b/pkg/client/clustersmgmt/v1/cluster_builder.go
@@ -78,9 +78,6 @@ type ClusterBuilder struct {
 	properties        map[string]string
 	state             *ClusterState
 	managed           *bool
-	memory            *ClusterMetricBuilder
-	cpu               *ClusterMetricBuilder
-	storage           *ClusterMetricBuilder
 	externalID        *string
 	aws               *AWSBuilder
 	network           *NetworkBuilder
@@ -92,6 +89,7 @@ type ClusterBuilder struct {
 	creator           *string
 	version           *VersionBuilder
 	identityProviders []*IdentityProviderBuilder
+	metrics           *ClusterMetricsBuilder
 }
 
 // NewCluster creates a new builder of 'cluster' objects.
@@ -226,36 +224,6 @@ func (b *ClusterBuilder) Managed(value bool) *ClusterBuilder {
 	return b
 }
 
-// Memory sets the value of the 'memory' attribute
-// to the given value.
-//
-// Metric describing the total and used amount of some resource (like RAM, CPU and storage) in
-// a cluster.
-func (b *ClusterBuilder) Memory(value *ClusterMetricBuilder) *ClusterBuilder {
-	b.memory = value
-	return b
-}
-
-// CPU sets the value of the 'CPU' attribute
-// to the given value.
-//
-// Metric describing the total and used amount of some resource (like RAM, CPU and storage) in
-// a cluster.
-func (b *ClusterBuilder) CPU(value *ClusterMetricBuilder) *ClusterBuilder {
-	b.cpu = value
-	return b
-}
-
-// Storage sets the value of the 'storage' attribute
-// to the given value.
-//
-// Metric describing the total and used amount of some resource (like RAM, CPU and storage) in
-// a cluster.
-func (b *ClusterBuilder) Storage(value *ClusterMetricBuilder) *ClusterBuilder {
-	b.storage = value
-	return b
-}
-
 // ExternalID sets the value of the 'external_ID' attribute
 // to the given value.
 //
@@ -337,6 +305,15 @@ func (b *ClusterBuilder) Version(value *VersionBuilder) *ClusterBuilder {
 	return b
 }
 
+// Metrics sets the value of the 'metrics' attribute
+// to the given value.
+//
+// Cluster metrics received via telemetry.
+func (b *ClusterBuilder) Metrics(value *ClusterMetricsBuilder) *ClusterBuilder {
+	b.metrics = value
+	return b
+}
+
 // Build creates a 'cluster' object using the configuration stored in the builder.
 func (b *ClusterBuilder) Build() (object *Cluster, err error) {
 	object = new(Cluster)
@@ -396,24 +373,6 @@ func (b *ClusterBuilder) Build() (object *Cluster, err error) {
 	}
 	if b.managed != nil {
 		object.managed = b.managed
-	}
-	if b.memory != nil {
-		object.memory, err = b.memory.Build()
-		if err != nil {
-			return
-		}
-	}
-	if b.cpu != nil {
-		object.cpu, err = b.cpu.Build()
-		if err != nil {
-			return
-		}
-	}
-	if b.storage != nil {
-		object.storage, err = b.storage.Build()
-		if err != nil {
-			return
-		}
 	}
 	if b.externalID != nil {
 		object.externalID = b.externalID
@@ -475,6 +434,12 @@ func (b *ClusterBuilder) Build() (object *Cluster, err error) {
 			if err != nil {
 				return
 			}
+		}
+	}
+	if b.metrics != nil {
+		object.metrics, err = b.metrics.Build()
+		if err != nil {
+			return
 		}
 	}
 	return

--- a/pkg/client/clustersmgmt/v1/cluster_console_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_console_type.go
@@ -26,6 +26,12 @@ type ClusterConsole struct {
 	url *string
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ClusterConsole) Empty() bool {
+	return o == nil || (o.url == nil &&
+		true)
+}
+
 // URL returns the value of the 'URL' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -60,6 +66,11 @@ func (l *ClusterConsoleList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *ClusterConsoleList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/cluster_credentials_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_credentials_type.go
@@ -95,6 +95,15 @@ func (o *ClusterCredentials) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ClusterCredentials) Empty() bool {
+	return o == nil || (o.id == nil &&
+		o.kubeconfig == nil &&
+		o.ssh == nil &&
+		o.admin == nil &&
+		true)
+}
+
 // Kubeconfig returns the value of the 'kubeconfig' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -225,6 +234,11 @@ func (l *ClusterCredentialsList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *ClusterCredentialsList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/cluster_metric_builder.go
+++ b/pkg/client/clustersmgmt/v1/cluster_metric_builder.go
@@ -19,18 +19,32 @@ limitations under the License.
 
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
 
+import (
+	time "time"
+)
+
 // ClusterMetricBuilder contains the data and logic needed to build 'cluster_metric' objects.
 //
 // Metric describing the total and used amount of some resource (like RAM, CPU and storage) in
 // a cluster.
 type ClusterMetricBuilder struct {
-	total *ValueBuilder
-	used  *ValueBuilder
+	updatedTimestamp *time.Time
+	total            *ValueBuilder
+	used             *ValueBuilder
 }
 
 // NewClusterMetric creates a new builder of 'cluster_metric' objects.
 func NewClusterMetric() *ClusterMetricBuilder {
 	return new(ClusterMetricBuilder)
+}
+
+// UpdatedTimestamp sets the value of the 'updated_timestamp' attribute
+// to the given value.
+//
+//
+func (b *ClusterMetricBuilder) UpdatedTimestamp(value time.Time) *ClusterMetricBuilder {
+	b.updatedTimestamp = &value
+	return b
 }
 
 // Total sets the value of the 'total' attribute
@@ -88,6 +102,9 @@ func (b *ClusterMetricBuilder) Used(value *ValueBuilder) *ClusterMetricBuilder {
 // Build creates a 'cluster_metric' object using the configuration stored in the builder.
 func (b *ClusterMetricBuilder) Build() (object *ClusterMetric, err error) {
 	object = new(ClusterMetric)
+	if b.updatedTimestamp != nil {
+		object.updatedTimestamp = b.updatedTimestamp
+	}
 	if b.total != nil {
 		object.total, err = b.total.Build()
 		if err != nil {

--- a/pkg/client/clustersmgmt/v1/cluster_metric_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_metric_type.go
@@ -19,13 +19,49 @@ limitations under the License.
 
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
 
+import (
+	time "time"
+)
+
 // ClusterMetric represents the values of the 'cluster_metric' type.
 //
 // Metric describing the total and used amount of some resource (like RAM, CPU and storage) in
 // a cluster.
 type ClusterMetric struct {
-	total *Value
-	used  *Value
+	updatedTimestamp *time.Time
+	total            *Value
+	used             *Value
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ClusterMetric) Empty() bool {
+	return o == nil || (o.updatedTimestamp == nil &&
+		o.total == nil &&
+		o.used == nil &&
+		true)
+}
+
+// UpdatedTimestamp returns the value of the 'updated_timestamp' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Collection timestamp of the metric.
+func (o *ClusterMetric) UpdatedTimestamp() time.Time {
+	if o != nil && o.updatedTimestamp != nil {
+		return *o.updatedTimestamp
+	}
+	return time.Time{}
+}
+
+// GetUpdatedTimestamp returns the value of the 'updated_timestamp' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Collection timestamp of the metric.
+func (o *ClusterMetric) GetUpdatedTimestamp() (value time.Time, ok bool) {
+	ok = o != nil && o.updatedTimestamp != nil
+	if ok {
+		value = *o.updatedTimestamp
+	}
+	return
 }
 
 // Total returns the value of the 'total' attribute, or
@@ -89,6 +125,11 @@ func (l *ClusterMetricList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *ClusterMetricList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/cluster_metrics_builder.go
+++ b/pkg/client/clustersmgmt/v1/cluster_metrics_builder.go
@@ -1,0 +1,104 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
+
+// ClusterMetricsBuilder contains the data and logic needed to build 'cluster_metrics' objects.
+//
+// Cluster metrics received via telemetry.
+type ClusterMetricsBuilder struct {
+	cpu     *ClusterMetricBuilder
+	memory  *ClusterMetricBuilder
+	storage *ClusterMetricBuilder
+	nodes   *ClusterNodesBuilder
+}
+
+// NewClusterMetrics creates a new builder of 'cluster_metrics' objects.
+func NewClusterMetrics() *ClusterMetricsBuilder {
+	return new(ClusterMetricsBuilder)
+}
+
+// CPU sets the value of the 'CPU' attribute
+// to the given value.
+//
+// Metric describing the total and used amount of some resource (like RAM, CPU and storage) in
+// a cluster.
+func (b *ClusterMetricsBuilder) CPU(value *ClusterMetricBuilder) *ClusterMetricsBuilder {
+	b.cpu = value
+	return b
+}
+
+// Memory sets the value of the 'memory' attribute
+// to the given value.
+//
+// Metric describing the total and used amount of some resource (like RAM, CPU and storage) in
+// a cluster.
+func (b *ClusterMetricsBuilder) Memory(value *ClusterMetricBuilder) *ClusterMetricsBuilder {
+	b.memory = value
+	return b
+}
+
+// Storage sets the value of the 'storage' attribute
+// to the given value.
+//
+// Metric describing the total and used amount of some resource (like RAM, CPU and storage) in
+// a cluster.
+func (b *ClusterMetricsBuilder) Storage(value *ClusterMetricBuilder) *ClusterMetricsBuilder {
+	b.storage = value
+	return b
+}
+
+// Nodes sets the value of the 'nodes' attribute
+// to the given value.
+//
+// Counts of different classes of nodes inside a cluster.
+func (b *ClusterMetricsBuilder) Nodes(value *ClusterNodesBuilder) *ClusterMetricsBuilder {
+	b.nodes = value
+	return b
+}
+
+// Build creates a 'cluster_metrics' object using the configuration stored in the builder.
+func (b *ClusterMetricsBuilder) Build() (object *ClusterMetrics, err error) {
+	object = new(ClusterMetrics)
+	if b.cpu != nil {
+		object.cpu, err = b.cpu.Build()
+		if err != nil {
+			return
+		}
+	}
+	if b.memory != nil {
+		object.memory, err = b.memory.Build()
+		if err != nil {
+			return
+		}
+	}
+	if b.storage != nil {
+		object.storage, err = b.storage.Build()
+		if err != nil {
+			return
+		}
+	}
+	if b.nodes != nil {
+		object.nodes, err = b.nodes.Build()
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/pkg/client/clustersmgmt/v1/cluster_metrics_list_builder.go
+++ b/pkg/client/clustersmgmt/v1/cluster_metrics_list_builder.go
@@ -1,0 +1,53 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
+
+// ClusterMetricsListBuilder contains the data and logic needed to build
+// 'cluster_metrics' objects.
+type ClusterMetricsListBuilder struct {
+	items []*ClusterMetricsBuilder
+}
+
+// NewClusterMetricsList creates a new builder of 'cluster_metrics' objects.
+func NewClusterMetricsList() *ClusterMetricsListBuilder {
+	return new(ClusterMetricsListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *ClusterMetricsListBuilder) Items(values ...*ClusterMetricsBuilder) *ClusterMetricsListBuilder {
+	b.items = make([]*ClusterMetricsBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Build creates a list of 'cluster_metrics' objects using the
+// configuration stored in the builder.
+func (b *ClusterMetricsListBuilder) Build() (list *ClusterMetricsList, err error) {
+	items := make([]*ClusterMetrics, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ClusterMetricsList)
+	list.items = items
+	return
+}

--- a/pkg/client/clustersmgmt/v1/cluster_metrics_list_reader.go
+++ b/pkg/client/clustersmgmt/v1/cluster_metrics_list_reader.go
@@ -1,0 +1,79 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
+
+import (
+	"github.com/openshift-online/uhc-sdk-go/pkg/client/helpers"
+)
+
+// clusterMetricsListData is type used internally to marshal and unmarshal lists of objects
+// of type 'cluster_metrics'.
+type clusterMetricsListData []*clusterMetricsData
+
+// UnmarshalClusterMetricsList reads a list of values of the 'cluster_metrics'
+// from the given source, which can be a slice of bytes, a string, an io.Reader or a
+// json.Decoder.
+func UnmarshalClusterMetricsList(source interface{}) (list *ClusterMetricsList, err error) {
+	decoder, err := helpers.NewDecoder(source)
+	if err != nil {
+		return
+	}
+	var data clusterMetricsListData
+	err = decoder.Decode(&data)
+	if err != nil {
+		return
+	}
+	list, err = data.unwrap()
+	return
+}
+
+// wrap is the method used internally to convert a list of values of the
+// 'cluster_metrics' value to a JSON document.
+func (l *ClusterMetricsList) wrap() (data clusterMetricsListData, err error) {
+	if l == nil {
+		return
+	}
+	data = make(clusterMetricsListData, len(l.items))
+	for i, item := range l.items {
+		data[i], err = item.wrap()
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// unwrap is the function used internally to convert the JSON unmarshalled data to a
+// list of values of the 'cluster_metrics' type.
+func (d clusterMetricsListData) unwrap() (list *ClusterMetricsList, err error) {
+	if d == nil {
+		return
+	}
+	items := make([]*ClusterMetrics, len(d))
+	for i, item := range d {
+		items[i], err = item.unwrap()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ClusterMetricsList)
+	list.items = items
+	return
+}

--- a/pkg/client/clustersmgmt/v1/cluster_metrics_reader.go
+++ b/pkg/client/clustersmgmt/v1/cluster_metrics_reader.go
@@ -20,22 +20,21 @@ limitations under the License.
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
 
 import (
-	time "time"
-
 	"github.com/openshift-online/uhc-sdk-go/pkg/client/helpers"
 )
 
-// clusterMetricData is the data structure used internally to marshal and unmarshal
-// objects of type 'cluster_metric'.
-type clusterMetricData struct {
-	UpdatedTimestamp *time.Time "json:\"updated_timestamp,omitempty\""
-	Total            *valueData "json:\"total,omitempty\""
-	Used             *valueData "json:\"used,omitempty\""
+// clusterMetricsData is the data structure used internally to marshal and unmarshal
+// objects of type 'cluster_metrics'.
+type clusterMetricsData struct {
+	CPU     *clusterMetricData "json:\"cpu,omitempty\""
+	Memory  *clusterMetricData "json:\"memory,omitempty\""
+	Storage *clusterMetricData "json:\"storage,omitempty\""
+	Nodes   *clusterNodesData  "json:\"nodes,omitempty\""
 }
 
-// MarshalClusterMetric writes a value of the 'cluster_metric' to the given target,
+// MarshalClusterMetrics writes a value of the 'cluster_metrics' to the given target,
 // which can be a writer or a JSON encoder.
-func MarshalClusterMetric(object *ClusterMetric, target interface{}) error {
+func MarshalClusterMetrics(object *ClusterMetrics, target interface{}) error {
 	encoder, err := helpers.NewEncoder(target)
 	if err != nil {
 		return err
@@ -47,33 +46,40 @@ func MarshalClusterMetric(object *ClusterMetric, target interface{}) error {
 	return encoder.Encode(data)
 }
 
-// wrap is the method used internally to convert a value of the 'cluster_metric'
+// wrap is the method used internally to convert a value of the 'cluster_metrics'
 // value to a JSON document.
-func (o *ClusterMetric) wrap() (data *clusterMetricData, err error) {
+func (o *ClusterMetrics) wrap() (data *clusterMetricsData, err error) {
 	if o == nil {
 		return
 	}
-	data = new(clusterMetricData)
-	data.UpdatedTimestamp = o.updatedTimestamp
-	data.Total, err = o.total.wrap()
+	data = new(clusterMetricsData)
+	data.CPU, err = o.cpu.wrap()
 	if err != nil {
 		return
 	}
-	data.Used, err = o.used.wrap()
+	data.Memory, err = o.memory.wrap()
+	if err != nil {
+		return
+	}
+	data.Storage, err = o.storage.wrap()
+	if err != nil {
+		return
+	}
+	data.Nodes, err = o.nodes.wrap()
 	if err != nil {
 		return
 	}
 	return
 }
 
-// UnmarshalClusterMetric reads a value of the 'cluster_metric' type from the given
+// UnmarshalClusterMetrics reads a value of the 'cluster_metrics' type from the given
 // source, which can be an slice of bytes, a string, a reader or a JSON decoder.
-func UnmarshalClusterMetric(source interface{}) (object *ClusterMetric, err error) {
+func UnmarshalClusterMetrics(source interface{}) (object *ClusterMetrics, err error) {
 	decoder, err := helpers.NewDecoder(source)
 	if err != nil {
 		return
 	}
-	data := new(clusterMetricData)
+	data := new(clusterMetricsData)
 	err = decoder.Decode(data)
 	if err != nil {
 		return
@@ -83,18 +89,25 @@ func UnmarshalClusterMetric(source interface{}) (object *ClusterMetric, err erro
 }
 
 // unwrap is the function used internally to convert the JSON unmarshalled data to a
-// value of the 'cluster_metric' type.
-func (d *clusterMetricData) unwrap() (object *ClusterMetric, err error) {
+// value of the 'cluster_metrics' type.
+func (d *clusterMetricsData) unwrap() (object *ClusterMetrics, err error) {
 	if d == nil {
 		return
 	}
-	object = new(ClusterMetric)
-	object.updatedTimestamp = d.UpdatedTimestamp
-	object.total, err = d.Total.unwrap()
+	object = new(ClusterMetrics)
+	object.cpu, err = d.CPU.unwrap()
 	if err != nil {
 		return
 	}
-	object.used, err = d.Used.unwrap()
+	object.memory, err = d.Memory.unwrap()
+	if err != nil {
+		return
+	}
+	object.storage, err = d.Storage.unwrap()
+	if err != nil {
+		return
+	}
+	object.nodes, err = d.Nodes.unwrap()
 	if err != nil {
 		return
 	}

--- a/pkg/client/clustersmgmt/v1/cluster_metrics_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_metrics_type.go
@@ -19,124 +19,128 @@ limitations under the License.
 
 package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
 
-// Ldapattributes represents the values of the 'ldapattributes' type.
+// ClusterMetrics represents the values of the 'cluster_metrics' type.
 //
-// LDAP attributes used to configure the LDAP identity provider.
-type Ldapattributes struct {
-	email             []string
-	id                []string
-	name              []string
-	preferredUsername []string
+// Cluster metrics received via telemetry.
+type ClusterMetrics struct {
+	cpu     *ClusterMetric
+	memory  *ClusterMetric
+	storage *ClusterMetric
+	nodes   *ClusterNodes
 }
 
 // Empty returns true if the object is empty, i.e. no attribute has a value.
-func (o *Ldapattributes) Empty() bool {
-	return o == nil || (o.email == nil &&
-		o.id == nil &&
-		o.name == nil &&
-		o.preferredUsername == nil &&
+func (o *ClusterMetrics) Empty() bool {
+	return o == nil || (o.cpu == nil &&
+		o.memory == nil &&
+		o.storage == nil &&
+		o.nodes == nil &&
 		true)
 }
 
-// Email returns the value of the 'email' attribute, or
+// CPU returns the value of the 'CPU' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
-// List of attributes to use as the mail address.
-func (o *Ldapattributes) Email() []string {
+// The amount of CPU provisioned and used in the cluster.
+func (o *ClusterMetrics) CPU() *ClusterMetric {
 	if o == nil {
 		return nil
 	}
-	return o.email
+	return o.cpu
 }
 
-// GetEmail returns the value of the 'email' attribute and
+// GetCPU returns the value of the 'CPU' attribute and
 // a flag indicating if the attribute has a value.
 //
-// List of attributes to use as the mail address.
-func (o *Ldapattributes) GetEmail() (value []string, ok bool) {
-	ok = o != nil && o.email != nil
+// The amount of CPU provisioned and used in the cluster.
+func (o *ClusterMetrics) GetCPU() (value *ClusterMetric, ok bool) {
+	ok = o != nil && o.cpu != nil
 	if ok {
-		value = o.email
+		value = o.cpu
 	}
 	return
 }
 
-// ID returns the value of the 'ID' attribute, or
+// Memory returns the value of the 'memory' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
-// List of attributes to use as the identity.
-func (o *Ldapattributes) ID() []string {
+// The amount of memory provisioned and used in the cluster.
+func (o *ClusterMetrics) Memory() *ClusterMetric {
 	if o == nil {
 		return nil
 	}
-	return o.id
+	return o.memory
 }
 
-// GetID returns the value of the 'ID' attribute and
+// GetMemory returns the value of the 'memory' attribute and
 // a flag indicating if the attribute has a value.
 //
-// List of attributes to use as the identity.
-func (o *Ldapattributes) GetID() (value []string, ok bool) {
-	ok = o != nil && o.id != nil
+// The amount of memory provisioned and used in the cluster.
+func (o *ClusterMetrics) GetMemory() (value *ClusterMetric, ok bool) {
+	ok = o != nil && o.memory != nil
 	if ok {
-		value = o.id
+		value = o.memory
 	}
 	return
 }
 
-// Name returns the value of the 'name' attribute, or
+// Storage returns the value of the 'storage' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
-// List of attributes to use as the display name.
-func (o *Ldapattributes) Name() []string {
+// The amount of storage provisioned and used in the cluster.
+//
+// WARNING: This isn't currently populated.
+func (o *ClusterMetrics) Storage() *ClusterMetric {
 	if o == nil {
 		return nil
 	}
-	return o.name
+	return o.storage
 }
 
-// GetName returns the value of the 'name' attribute and
+// GetStorage returns the value of the 'storage' attribute and
 // a flag indicating if the attribute has a value.
 //
-// List of attributes to use as the display name.
-func (o *Ldapattributes) GetName() (value []string, ok bool) {
-	ok = o != nil && o.name != nil
+// The amount of storage provisioned and used in the cluster.
+//
+// WARNING: This isn't currently populated.
+func (o *ClusterMetrics) GetStorage() (value *ClusterMetric, ok bool) {
+	ok = o != nil && o.storage != nil
 	if ok {
-		value = o.name
+		value = o.storage
 	}
 	return
 }
 
-// PreferredUsername returns the value of the 'preferred_username' attribute, or
+// Nodes returns the value of the 'nodes' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
-// List of attributes to use as the preferred user name when provisioning a user.
-func (o *Ldapattributes) PreferredUsername() []string {
+// The number of nodes provisioned for the cluster.
+func (o *ClusterMetrics) Nodes() *ClusterNodes {
 	if o == nil {
 		return nil
 	}
-	return o.preferredUsername
+	return o.nodes
 }
 
-// GetPreferredUsername returns the value of the 'preferred_username' attribute and
+// GetNodes returns the value of the 'nodes' attribute and
 // a flag indicating if the attribute has a value.
 //
-// List of attributes to use as the preferred user name when provisioning a user.
-func (o *Ldapattributes) GetPreferredUsername() (value []string, ok bool) {
-	ok = o != nil && o.preferredUsername != nil
+// The number of nodes provisioned for the cluster.
+func (o *ClusterMetrics) GetNodes() (value *ClusterNodes, ok bool) {
+	ok = o != nil && o.nodes != nil
 	if ok {
-		value = o.preferredUsername
+		value = o.nodes
 	}
 	return
 }
 
-// LdapattributesList is a list of values of the 'ldapattributes' type.
-type LdapattributesList struct {
-	items []*Ldapattributes
+// ClusterMetricsList is a list of values of the 'cluster_metrics' type.
+type ClusterMetricsList struct {
+	items []*ClusterMetrics
 }
 
 // Len returns the length of the list.
-func (l *LdapattributesList) Len() int {
+func (l *ClusterMetricsList) Len() int {
 	if l == nil {
 		return 0
 	}
@@ -144,7 +148,7 @@ func (l *LdapattributesList) Len() int {
 }
 
 // Empty returns true if the list is empty.
-func (l *LdapattributesList) Empty() bool {
+func (l *ClusterMetricsList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
@@ -154,12 +158,12 @@ func (l *LdapattributesList) Empty() bool {
 //
 // If you don't need to modify the returned slice consider using the Each or Range
 // functions, as they don't need to allocate a new slice.
-func (l *LdapattributesList) Slice() []*Ldapattributes {
-	var slice []*Ldapattributes
+func (l *ClusterMetricsList) Slice() []*ClusterMetrics {
+	var slice []*ClusterMetrics
 	if l == nil {
-		slice = make([]*Ldapattributes, 0)
+		slice = make([]*ClusterMetrics, 0)
 	} else {
-		slice = make([]*Ldapattributes, len(l.items))
+		slice = make([]*ClusterMetrics, len(l.items))
 		copy(slice, l.items)
 	}
 	return slice
@@ -168,7 +172,7 @@ func (l *LdapattributesList) Slice() []*Ldapattributes {
 // Each runs the given function for each item of the list, in order. If the function
 // returns false the iteration stops, otherwise it continues till all the elements
 // of the list have been processed.
-func (l *LdapattributesList) Each(f func(item *Ldapattributes) bool) {
+func (l *ClusterMetricsList) Each(f func(item *ClusterMetrics) bool) {
 	if l == nil {
 		return
 	}
@@ -182,7 +186,7 @@ func (l *LdapattributesList) Each(f func(item *Ldapattributes) bool) {
 // Range runs the given function for each index and item of the list, in order. If
 // the function returns false the iteration stops, otherwise it continues till all
 // the elements of the list have been processed.
-func (l *LdapattributesList) Range(f func(index int, item *Ldapattributes) bool) {
+func (l *ClusterMetricsList) Range(f func(index int, item *ClusterMetrics) bool) {
 	if l == nil {
 		return
 	}

--- a/pkg/client/clustersmgmt/v1/cluster_nodes_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_nodes_type.go
@@ -29,6 +29,15 @@ type ClusterNodes struct {
 	compute *int
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ClusterNodes) Empty() bool {
+	return o == nil || (o.total == nil &&
+		o.master == nil &&
+		o.infra == nil &&
+		o.compute == nil &&
+		true)
+}
+
 // Total returns the value of the 'total' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -132,6 +141,11 @@ func (l *ClusterNodesList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *ClusterNodesList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/cluster_reader.go
+++ b/pkg/client/clustersmgmt/v1/cluster_reader.go
@@ -44,9 +44,6 @@ type clusterData struct {
 	Properties        map[string]string             "json:\"properties,omitempty\""
 	State             *ClusterState                 "json:\"state,omitempty\""
 	Managed           *bool                         "json:\"managed,omitempty\""
-	Memory            *clusterMetricData            "json:\"memory,omitempty\""
-	CPU               *clusterMetricData            "json:\"cpu,omitempty\""
-	Storage           *clusterMetricData            "json:\"storage,omitempty\""
 	ExternalID        *string                       "json:\"external_id,omitempty\""
 	AWS               *awsData                      "json:\"aws,omitempty\""
 	Network           *networkData                  "json:\"network,omitempty\""
@@ -58,6 +55,7 @@ type clusterData struct {
 	Creator           *string                       "json:\"creator,omitempty\""
 	Version           *versionData                  "json:\"version,omitempty\""
 	IdentityProviders *identityProviderListLinkData "json:\"identity_providers,omitempty\""
+	Metrics           *clusterMetricsData           "json:\"metrics,omitempty\""
 }
 
 // MarshalCluster writes a value of the 'cluster' to the given target,
@@ -119,18 +117,6 @@ func (o *Cluster) wrap() (data *clusterData, err error) {
 	data.Properties = o.properties
 	data.State = o.state
 	data.Managed = o.managed
-	data.Memory, err = o.memory.wrap()
-	if err != nil {
-		return
-	}
-	data.CPU, err = o.cpu.wrap()
-	if err != nil {
-		return
-	}
-	data.Storage, err = o.storage.wrap()
-	if err != nil {
-		return
-	}
 	data.ExternalID = o.externalID
 	data.AWS, err = o.aws.wrap()
 	if err != nil {
@@ -160,6 +146,10 @@ func (o *Cluster) wrap() (data *clusterData, err error) {
 		return
 	}
 	data.IdentityProviders, err = o.identityProviders.wrapLink()
+	if err != nil {
+		return
+	}
+	data.Metrics, err = o.metrics.wrap()
 	if err != nil {
 		return
 	}
@@ -237,18 +227,6 @@ func (d *clusterData) unwrap() (object *Cluster, err error) {
 	object.properties = d.Properties
 	object.state = d.State
 	object.managed = d.Managed
-	object.memory, err = d.Memory.unwrap()
-	if err != nil {
-		return
-	}
-	object.cpu, err = d.CPU.unwrap()
-	if err != nil {
-		return
-	}
-	object.storage, err = d.Storage.unwrap()
-	if err != nil {
-		return
-	}
 	object.externalID = d.ExternalID
 	object.aws, err = d.AWS.unwrap()
 	if err != nil {
@@ -278,6 +256,10 @@ func (d *clusterData) unwrap() (object *Cluster, err error) {
 		return
 	}
 	object.identityProviders, err = d.IdentityProviders.unwrapLink()
+	if err != nil {
+		return
+	}
+	object.metrics, err = d.Metrics.unwrap()
 	if err != nil {
 		return
 	}

--- a/pkg/client/clustersmgmt/v1/cluster_registration_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_registration_type.go
@@ -27,6 +27,13 @@ type ClusterRegistration struct {
 	externalID     *string
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ClusterRegistration) Empty() bool {
+	return o == nil || (o.subscriptionID == nil &&
+		o.externalID == nil &&
+		true)
+}
+
 // SubscriptionID returns the value of the 'subscription_ID' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -120,6 +127,11 @@ func (l *ClusterRegistrationList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *ClusterRegistrationList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/cluster_status_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_status_type.go
@@ -94,6 +94,14 @@ func (o *ClusterStatus) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ClusterStatus) Empty() bool {
+	return o == nil || (o.id == nil &&
+		o.state == nil &&
+		o.description == nil &&
+		true)
+}
+
 // State returns the value of the 'state' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -199,6 +207,11 @@ func (l *ClusterStatusList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *ClusterStatusList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/cluster_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_type.go
@@ -90,9 +90,6 @@ type Cluster struct {
 	properties        map[string]string
 	state             *ClusterState
 	managed           *bool
-	memory            *ClusterMetric
-	cpu               *ClusterMetric
-	storage           *ClusterMetric
 	externalID        *string
 	aws               *AWS
 	network           *Network
@@ -104,6 +101,7 @@ type Cluster struct {
 	creator           *string
 	version           *Version
 	identityProviders *IdentityProviderList
+	metrics           *ClusterMetrics
 }
 
 // Kind returns the name of the type of the object.
@@ -156,6 +154,36 @@ func (o *Cluster) GetHREF() (value string, ok bool) {
 		value = *o.href
 	}
 	return
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *Cluster) Empty() bool {
+	return o == nil || (o.id == nil &&
+		o.name == nil &&
+		o.flavour == nil &&
+		o.console == nil &&
+		o.multiAZ == nil &&
+		o.nodes == nil &&
+		o.api == nil &&
+		o.region == nil &&
+		o.displayName == nil &&
+		o.dns == nil &&
+		o.properties == nil &&
+		o.state == nil &&
+		o.managed == nil &&
+		o.externalID == nil &&
+		o.aws == nil &&
+		o.network == nil &&
+		o.creationTimestamp == nil &&
+		o.cloudProvider == nil &&
+		o.openshiftVersion == nil &&
+		o.subscription == nil &&
+		o.groups.Empty() &&
+		o.creator == nil &&
+		o.version == nil &&
+		o.identityProviders.Empty() &&
+		o.metrics == nil &&
+		true)
 }
 
 // Name returns the value of the 'name' attribute, or
@@ -444,75 +472,6 @@ func (o *Cluster) GetManaged() (value bool, ok bool) {
 	return
 }
 
-// Memory returns the value of the 'memory' attribute, or
-// the zero value of the type if the attribute doesn't have a value.
-//
-// Information about the memory of the cluster.
-func (o *Cluster) Memory() *ClusterMetric {
-	if o == nil {
-		return nil
-	}
-	return o.memory
-}
-
-// GetMemory returns the value of the 'memory' attribute and
-// a flag indicating if the attribute has a value.
-//
-// Information about the memory of the cluster.
-func (o *Cluster) GetMemory() (value *ClusterMetric, ok bool) {
-	ok = o != nil && o.memory != nil
-	if ok {
-		value = o.memory
-	}
-	return
-}
-
-// CPU returns the value of the 'CPU' attribute, or
-// the zero value of the type if the attribute doesn't have a value.
-//
-// Information about the CPU of the cluster.
-func (o *Cluster) CPU() *ClusterMetric {
-	if o == nil {
-		return nil
-	}
-	return o.cpu
-}
-
-// GetCPU returns the value of the 'CPU' attribute and
-// a flag indicating if the attribute has a value.
-//
-// Information about the CPU of the cluster.
-func (o *Cluster) GetCPU() (value *ClusterMetric, ok bool) {
-	ok = o != nil && o.cpu != nil
-	if ok {
-		value = o.cpu
-	}
-	return
-}
-
-// Storage returns the value of the 'storage' attribute, or
-// the zero value of the type if the attribute doesn't have a value.
-//
-// Information about the storage of the cluster.
-func (o *Cluster) Storage() *ClusterMetric {
-	if o == nil {
-		return nil
-	}
-	return o.storage
-}
-
-// GetStorage returns the value of the 'storage' attribute and
-// a flag indicating if the attribute has a value.
-//
-// Information about the storage of the cluster.
-func (o *Cluster) GetStorage() (value *ClusterMetric, ok bool) {
-	ok = o != nil && o.storage != nil
-	if ok {
-		value = o.storage
-	}
-	return
-}
-
 // ExternalID returns the value of the 'external_ID' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -780,6 +739,33 @@ func (o *Cluster) GetIdentityProviders() (value *IdentityProviderList, ok bool) 
 	return
 }
 
+// Metrics returns the value of the 'metrics' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Cluster metrics received from telemetry.
+//
+// When provisioning a cluster this will be ignored.
+func (o *Cluster) Metrics() *ClusterMetrics {
+	if o == nil {
+		return nil
+	}
+	return o.metrics
+}
+
+// GetMetrics returns the value of the 'metrics' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Cluster metrics received from telemetry.
+//
+// When provisioning a cluster this will be ignored.
+func (o *Cluster) GetMetrics() (value *ClusterMetrics, ok bool) {
+	ok = o != nil && o.metrics != nil
+	if ok {
+		value = o.metrics
+	}
+	return
+}
+
 // ClusterListKind is the name of the type used to represent list of
 // objects of type 'cluster'.
 const ClusterListKind = "ClusterList"
@@ -839,6 +825,11 @@ func (l *ClusterList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *ClusterList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/clusters_client.go
+++ b/pkg/client/clustersmgmt/v1/clusters_client.go
@@ -101,13 +101,13 @@ func (r *ClustersListRequest) Context(value context.Context) *ClustersListReques
 	return r
 }
 
-// Timeout sets a timeout for the complete request.
+// Timeout sets a timeout for the completete request.
 func (r *ClustersListRequest) Timeout(value time.Duration) *ClustersListRequest {
 	helpers.SetTimeout(&r.context, &r.cancel, value)
 	return r
 }
 
-// Deadline sets a deadline for the complete request.
+// Deadline sets a deadline for the completete request.
 func (r *ClustersListRequest) Deadline(value time.Time) *ClustersListRequest {
 	helpers.SetDeadline(&r.context, &r.cancel, value)
 	return r

--- a/pkg/client/clustersmgmt/v1/dashboard_type.go
+++ b/pkg/client/clustersmgmt/v1/dashboard_type.go
@@ -93,6 +93,13 @@ func (o *Dashboard) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *Dashboard) Empty() bool {
+	return o == nil || (o.id == nil &&
+		o.metrics.Empty() &&
+		true)
+}
+
 // Metrics returns the value of the 'metrics' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -175,6 +182,11 @@ func (l *DashboardList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *DashboardList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/dns_type.go
+++ b/pkg/client/clustersmgmt/v1/dns_type.go
@@ -26,6 +26,12 @@ type DNS struct {
 	baseDomain *string
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *DNS) Empty() bool {
+	return o == nil || (o.baseDomain == nil &&
+		true)
+}
+
 // BaseDomain returns the value of the 'base_domain' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -146,6 +152,11 @@ func (l *DNSList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *DNSList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/flavour_type.go
+++ b/pkg/client/clustersmgmt/v1/flavour_type.go
@@ -98,6 +98,17 @@ func (o *Flavour) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *Flavour) Empty() bool {
+	return o == nil || (o.id == nil &&
+		o.aws == nil &&
+		o.version == nil &&
+		o.nodes == nil &&
+		o.name == nil &&
+		o.network == nil &&
+		true)
+}
+
 // AWS returns the value of the 'AWS' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -292,6 +303,11 @@ func (l *FlavourList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *FlavourList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/github_identity_provider_type.go
+++ b/pkg/client/clustersmgmt/v1/github_identity_provider_type.go
@@ -29,6 +29,15 @@ type GithubIdentityProvider struct {
 	teams    []string
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *GithubIdentityProvider) Empty() bool {
+	return o == nil || (o.ca == nil &&
+		o.clientID == nil &&
+		o.hostname == nil &&
+		o.teams == nil &&
+		true)
+}
+
 // CA returns the value of the 'CA' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -140,6 +149,11 @@ func (l *GithubIdentityProviderList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *GithubIdentityProviderList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/gitlab_identity_provider_type.go
+++ b/pkg/client/clustersmgmt/v1/gitlab_identity_provider_type.go
@@ -29,6 +29,15 @@ type GitlabIdentityProvider struct {
 	url          *string
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *GitlabIdentityProvider) Empty() bool {
+	return o == nil || (o.ca == nil &&
+		o.clientID == nil &&
+		o.clientSecret == nil &&
+		o.url == nil &&
+		true)
+}
+
 // CA returns the value of the 'CA' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -132,6 +141,11 @@ func (l *GitlabIdentityProviderList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *GitlabIdentityProviderList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/google_identity_provider_type.go
+++ b/pkg/client/clustersmgmt/v1/google_identity_provider_type.go
@@ -28,6 +28,14 @@ type GoogleIdentityProvider struct {
 	hostedDomain *string
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *GoogleIdentityProvider) Empty() bool {
+	return o == nil || (o.clientID == nil &&
+		o.clientSecret == nil &&
+		o.hostedDomain == nil &&
+		true)
+}
+
 // ClientID returns the value of the 'client_ID' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -108,6 +116,11 @@ func (l *GoogleIdentityProviderList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *GoogleIdentityProviderList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/group_type.go
+++ b/pkg/client/clustersmgmt/v1/group_type.go
@@ -93,6 +93,13 @@ func (o *Group) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *Group) Empty() bool {
+	return o == nil || (o.id == nil &&
+		o.users.Empty() &&
+		true)
+}
+
 // Users returns the value of the 'users' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -175,6 +182,11 @@ func (l *GroupList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *GroupList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/identity_provider_type.go
+++ b/pkg/client/clustersmgmt/v1/identity_provider_type.go
@@ -102,6 +102,22 @@ func (o *IdentityProvider) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *IdentityProvider) Empty() bool {
+	return o == nil || (o.id == nil &&
+		o.type_ == nil &&
+		o.name == nil &&
+		o.challenge == nil &&
+		o.login == nil &&
+		o.mappingMethod == nil &&
+		o.github == nil &&
+		o.gitlab == nil &&
+		o.google == nil &&
+		o.ldap == nil &&
+		o.openID == nil &&
+		true)
+}
+
 // Type returns the value of the 'type' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -401,6 +417,11 @@ func (l *IdentityProviderList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *IdentityProviderList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/ldapidentity_provider_type.go
+++ b/pkg/client/clustersmgmt/v1/ldapidentity_provider_type.go
@@ -31,6 +31,17 @@ type LdapidentityProvider struct {
 	insecure       *bool
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *LdapidentityProvider) Empty() bool {
+	return o == nil || (o.ldapattributes == nil &&
+		o.bindDN == nil &&
+		o.bindPassword == nil &&
+		o.ca == nil &&
+		o.url == nil &&
+		o.insecure == nil &&
+		true)
+}
+
 // Ldapattributes returns the value of the 'ldapattributes' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -184,6 +195,11 @@ func (l *LdapidentityProviderList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *LdapidentityProviderList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/log_type.go
+++ b/pkg/client/clustersmgmt/v1/log_type.go
@@ -93,6 +93,13 @@ func (o *Log) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *Log) Empty() bool {
+	return o == nil || (o.id == nil &&
+		o.content == nil &&
+		true)
+}
+
 // Content returns the value of the 'content' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -175,6 +182,11 @@ func (l *LogList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *LogList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/metric_type.go
+++ b/pkg/client/clustersmgmt/v1/metric_type.go
@@ -27,6 +27,13 @@ type Metric struct {
 	vector *SampleList
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *Metric) Empty() bool {
+	return o == nil || (o.name == nil &&
+		o.vector.Empty() &&
+		true)
+}
+
 // Name returns the value of the 'name' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -84,6 +91,11 @@ func (l *MetricList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *MetricList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/network_type.go
+++ b/pkg/client/clustersmgmt/v1/network_type.go
@@ -28,6 +28,14 @@ type Network struct {
 	serviceCIDR *string
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *Network) Empty() bool {
+	return o == nil || (o.podCIDR == nil &&
+		o.machineCIDR == nil &&
+		o.serviceCIDR == nil &&
+		true)
+}
+
 // PodCIDR returns the value of the 'pod_CIDR' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -108,6 +116,11 @@ func (l *NetworkList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *NetworkList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/open_idclaims_type.go
+++ b/pkg/client/clustersmgmt/v1/open_idclaims_type.go
@@ -28,6 +28,14 @@ type OpenIdclaims struct {
 	preferredUsername []string
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *OpenIdclaims) Empty() bool {
+	return o == nil || (o.email == nil &&
+		o.name == nil &&
+		o.preferredUsername == nil &&
+		true)
+}
+
 // Email returns the value of the 'email' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -108,6 +116,11 @@ func (l *OpenIdclaimsList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *OpenIdclaimsList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/open_ididentity_provider_type.go
+++ b/pkg/client/clustersmgmt/v1/open_ididentity_provider_type.go
@@ -32,6 +32,18 @@ type OpenIdidentityProvider struct {
 	urls                     *OpenIdurls
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *OpenIdidentityProvider) Empty() bool {
+	return o == nil || (o.ca == nil &&
+		o.claims == nil &&
+		o.clientID == nil &&
+		o.clientSecret == nil &&
+		o.extraAuthorizeParameters == nil &&
+		o.extraScopes == nil &&
+		o.urls == nil &&
+		true)
+}
+
 // CA returns the value of the 'CA' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -206,6 +218,11 @@ func (l *OpenIdidentityProviderList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *OpenIdidentityProviderList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/open_idurls_type.go
+++ b/pkg/client/clustersmgmt/v1/open_idurls_type.go
@@ -28,6 +28,14 @@ type OpenIdurls struct {
 	userInfo  *string
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *OpenIdurls) Empty() bool {
+	return o == nil || (o.authorize == nil &&
+		o.token == nil &&
+		o.userInfo == nil &&
+		true)
+}
+
 // Authorize returns the value of the 'authorize' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -108,6 +116,11 @@ func (l *OpenIdurlsList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *OpenIdurlsList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/root_client.go
+++ b/pkg/client/clustersmgmt/v1/root_client.go
@@ -33,7 +33,7 @@ type RootClient struct {
 }
 
 // NewRootClient creates a new client for the 'root'
-// resource using the given transport to send the requests and receive the
+// resource using the given transport to sned the requests and receive the
 // responses.
 func NewRootClient(transport http.RoundTripper, path string) *RootClient {
 	client := new(RootClient)

--- a/pkg/client/clustersmgmt/v1/sample_type.go
+++ b/pkg/client/clustersmgmt/v1/sample_type.go
@@ -31,6 +31,13 @@ type Sample struct {
 	value *float64
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *Sample) Empty() bool {
+	return o == nil || (o.time == nil &&
+		o.value == nil &&
+		true)
+}
+
 // Time returns the value of the 'time' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -88,6 +95,11 @@ func (l *SampleList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *SampleList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/sshcredentials_type.go
+++ b/pkg/client/clustersmgmt/v1/sshcredentials_type.go
@@ -27,6 +27,13 @@ type Sshcredentials struct {
 	privateKey *string
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *Sshcredentials) Empty() bool {
+	return o == nil || (o.publicKey == nil &&
+		o.privateKey == nil &&
+		true)
+}
+
 // PublicKey returns the value of the 'public_key' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -84,6 +91,11 @@ func (l *SshcredentialsList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *SshcredentialsList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/subscription_type.go
+++ b/pkg/client/clustersmgmt/v1/subscription_type.go
@@ -92,6 +92,12 @@ func (o *Subscription) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *Subscription) Empty() bool {
+	return o == nil || (o.id == nil &&
+		true)
+}
+
 // SubscriptionListKind is the name of the type used to represent list of
 // objects of type 'subscription'.
 const SubscriptionListKind = "SubscriptionList"
@@ -151,6 +157,11 @@ func (l *SubscriptionList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *SubscriptionList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/user_type.go
+++ b/pkg/client/clustersmgmt/v1/user_type.go
@@ -92,6 +92,12 @@ func (o *User) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *User) Empty() bool {
+	return o == nil || (o.id == nil &&
+		true)
+}
+
 // UserListKind is the name of the type used to represent list of
 // objects of type 'user'.
 const UserListKind = "UserList"
@@ -151,6 +157,11 @@ func (l *UserList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *UserList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/value_type.go
+++ b/pkg/client/clustersmgmt/v1/value_type.go
@@ -44,6 +44,13 @@ type Value struct {
 	unit  *string
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *Value) Empty() bool {
+	return o == nil || (o.value == nil &&
+		o.unit == nil &&
+		true)
+}
+
 // Value returns the value of the 'value' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -101,6 +108,11 @@ func (l *ValueList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *ValueList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a

--- a/pkg/client/clustersmgmt/v1/version_type.go
+++ b/pkg/client/clustersmgmt/v1/version_type.go
@@ -92,6 +92,12 @@ func (o *Version) GetHREF() (value string, ok bool) {
 	return
 }
 
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *Version) Empty() bool {
+	return o == nil || (o.id == nil &&
+		true)
+}
+
 // VersionListKind is the name of the type used to represent list of
 // objects of type 'version'.
 const VersionListKind = "VersionList"
@@ -151,6 +157,11 @@ func (l *VersionList) Len() int {
 		return 0
 	}
 	return len(l.items)
+}
+
+// Empty returns true if the list is empty.
+func (l *VersionList) Empty() bool {
+	return l == nil || len(l.items) == 0
 }
 
 // Slice returns an slice containing the items of the list. The returned slice is a


### PR DESCRIPTION
The API has recently be changed so that the basic metrics of the cluster
(total and used amount of CPU and memory) are now inside the `metrics`
attribute. This patch changes the SDK accordingly, and adds an example
that explains how to use those metrics.