### PR TITLE
Release 0.1.8

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,12 @@
 This document describes the relevant changes between releases of the UHC API
 SDK.
 
+== 0.1.8 May 2 2019
+
+- Moved basic cluster metrics to the `metrics` attribute.
+
+- Added `Empty` method to lists and struct typess.
+
 == 0.1.7 May 1 2019
 
 - Always close connections used to request access tokens.

--- a/pkg/client/version.go
+++ b/pkg/client/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package client
 
-const Version = "0.1.7"
+const Version = "0.1.8"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Moved basic cluster metrics to the `metrics` attribute.

- Added `Empty` method to lists and struct typess.