### PR TITLE
Increase token slack

### DIFF
--- a/pkg/client/token.go
+++ b/pkg/client/token.go
@@ -77,8 +77,8 @@ func (c *Connection) TokensContext(ctx context.Context) (access, refresh string,
 		c.debugExpiry(ctx, "Bearer", c.accessToken, accessExpires, accessLeft)
 		c.debugExpiry(ctx, "Refresh", c.refreshToken, refreshExpires, refreshLeft)
 	}
-	if c.accessToken == nil || (accessExpires && accessLeft < 5*time.Second) {
-		if c.refreshToken == nil || (refreshExpires && refreshLeft < 10*time.Second) {
+	if c.accessToken == nil || (accessExpires && accessLeft < 1*time.Minute) {
+		if c.refreshToken == nil || (refreshExpires && refreshLeft < 1*time.Minute) {
 			c.logger.Debug(ctx, "Requesting new token")
 			err = c.sendRequestTokenForm(ctx)
 			if err != nil {

--- a/pkg/client/token_test.go
+++ b/pkg/client/token_test.go
@@ -152,9 +152,9 @@ var _ = Describe("Tokens", func() {
 			Expect(returnedAccess).To(Equal(validAccess))
 		})
 
-		It("Refreshes the access token if it expires in less than 5 seconds", func() {
+		It("Refreshes the access token if it expires in less than one minute", func() {
 			// Generate the tokens:
-			firstAccess := Token("Bearer", 1*time.Second)
+			firstAccess := Token("Bearer", 50*time.Second)
 			secondAccess := Token("Bearer", 5*time.Minute)
 			refreshToken := Token("Refresh", 10*time.Hour)
 


### PR DESCRIPTION
Currently the SDK renews the access token when it will expire in five
seconds. That is two short, and in some situations it means that the
server receiving the token will consider it already expired, just
because it takes more than five seconds for the token to travel from the
client to the server. To reduce the chances of that problem this patch
changes the SDK so that it will renew the access and refresh tokens when
they expire in less than one minute.