### PR TITLE
Release 0.1.11

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the UHC API
 SDK.
 
+== 0.1.11 May 15 2019
+
+- Increase token slack to one minute.
+
 == 0.1.10 May 8 2019
 
 - Improved support for contexts, adding the `BuildContext`, `TokensContext` and

--- a/pkg/client/version.go
+++ b/pkg/client/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package client
 
-const Version = "0.1.10"
+const Version = "0.1.11"


### PR DESCRIPTION
The more relevant changes in this new release are the following:

- Increase token slack to one minute.