### PR TITLE
Redact sensitive information from log output

### DIFF
--- a/pkg/client/token.go
+++ b/pkg/client/token.go
@@ -191,9 +191,8 @@ func (c *Connection) sendTokenFormTimed(ctx context.Context, form url.Values) (c
 				}
 				censoredBody.WriteString(url.QueryEscape(name) + "=") // #nosec G104
 
-				if name == "password" || name == "client_secret" {
-					censoredBody.WriteString("***") // #nosec G104
-
+				if isRedactField(name) {
+					censoredBody.WriteString(redactionStr) // #nosec G104
 				} else {
 					censoredBody.WriteString(url.QueryEscape(value)) // #nosec G104
 				}


### PR DESCRIPTION
Adds option to remove a list of strings from log output. Both access and refresh tokens are automatically included.

External users can specify their own strings to be redacted using the log builders or `AddRedactStrs` once a logger has been created.

/cc @jhernand