### PR TITLE
Add Prometheus metrics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  pruneopts = "UT"
+  revision = "4b2b341e8d7715fae06375aa633dbb6e91b3fb46"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:76dc72490af7174349349838f2fe118996381b31ea83243812a97e5a0fd5ed55"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
@@ -38,6 +46,14 @@
   pruneopts = "UT"
   revision = "a30252cb686a21eb2d0b98132633053ec2f7f1e5"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  pruneopts = "UT"
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
 
 [[projects]]
   digest = "1:e9c3bb68a6c9470302b8046d4647e0612a2ea6037b9c6a47de60c0a90db504f8"
@@ -87,6 +103,49 @@
   pruneopts = "UT"
   revision = "90e289841c1ed79b7a598a7cd9959750cb5e89e2"
   version = "v1.5.0"
+
+[[projects]]
+  digest = "1:0de31727c88e9f4a4ae70c28b6caa27f39b25788daf2dc4f7406013421228144"
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/internal",
+    "prometheus/promhttp",
+  ]
+  pruneopts = "UT"
+  revision = "50c4339db732beb2165735d2cde0bff78eb3c5a5"
+  version = "v0.9.3"
+
+[[projects]]
+  branch = "master"
+  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  pruneopts = "UT"
+  revision = "fd36f4220a901265f90734c3183c5f0c91daa0b8"
+
+[[projects]]
+  digest = "1:35cf6bdf68db765988baa9c4f10cc5d7dda1126a54bd62e252dbcd0b1fc8da90"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = "UT"
+  revision = "1ba88736f028e37bc17328369e94a537ae9e0234"
+  version = "v0.4.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:febbae5fbeac5cdbe5506bed8a6110e7341e0e46b89b056d9888ddf8a6a2d136"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/fs",
+  ]
+  pruneopts = "UT"
+  revision = "169873baca24ac97d9ecff83a3b7e547b22832ba"
 
 [[projects]]
   branch = "master"
@@ -168,6 +227,8 @@
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",
     "github.com/onsi/gomega/ghttp",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/examples/prometheus_metrics.go
+++ b/examples/prometheus_metrics.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This example shows how to use the support for Prometheus metrics.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/openshift-online/uhc-sdk-go/pkg/client"
+	"github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1"
+)
+
+func main() {
+	// Create a context:
+	ctx := context.Background()
+
+	// Create and start a Prometheus metric server that will respond to any request in port
+	// 8000, regardless of the request path.
+	go http.ListenAndServe(":8000", promhttp.Handler())
+
+	// Create a logger that has the debug level enabled:
+	logger, err := client.NewGoLoggerBuilder().
+		Debug(true).
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build logger: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Create the connection, specifying the `api_outbound` subsystem so that metrics are
+	// enabled and available with the `api_outbound_` prefix.
+	token := os.Getenv("UHC_TOKEN")
+	connection, err := client.NewConnectionBuilder().
+		Logger(logger).
+		Tokens(token).
+		Metrics("my").
+		BuildContext(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build client: %v\n", err)
+		os.Exit(1)
+	}
+	defer connection.Close()
+
+	// Get the client for the resource that manages the collection of clusters:
+	clustersCollection := connection.ClustersMgmt().V1().Clusters()
+
+	// Send requests to retrieve the first page of clusters, the details of the cluster, the
+	// logs, and the credentials, in a loop, to accumulate metrics. To see the metrics point
+	// your browser to http://localhost:8000.
+	for {
+		// Get the list of clusters:
+		clustersListResponse, err := clustersCollection.List().SendContext(ctx)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Can't send list request: %v\n", err)
+			os.Exit(1)
+		}
+
+		// For each cluster:
+		clustersListResponse.Items().Each(func(cluster *v1.Cluster) bool {
+			// Get the details:
+			clusterResource := clustersCollection.Cluster(cluster.ID())
+			clusterResource.Get().SendContext(ctx)
+
+			// Get the list of logs:
+			logsResource := clusterResource.Logs()
+			logsResource.List().SendContext(ctx)
+
+			// Get the credentials:
+			credentialsResource := clusterResource.Credentials()
+			credentialsResource.Get().SendContext(ctx)
+
+			return true
+		})
+
+		// Wait a bit:
+		time.Sleep(1 * time.Second)
+	}
+}

--- a/pkg/client/accountsmgmt/client.go
+++ b/pkg/client/accountsmgmt/client.go
@@ -30,14 +30,16 @@ import (
 type Client struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewClient creates a new client for the service 'accounts_mgmt' using the
 // given transport to send the requests and receive the responses.
-func NewClient(transport http.RoundTripper, path string) *Client {
+func NewClient(transport http.RoundTripper, path string, metric string) *Client {
 	client := new(Client)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -46,5 +48,6 @@ func (c *Client) V1() *v1.RootClient {
 	return v1.NewRootClient(
 		c.transport,
 		path.Join(c.path, "v1"),
+		path.Join(c.metric, "v1"),
 	)
 }

--- a/pkg/client/accountsmgmt/v1/access_token_client.go
+++ b/pkg/client/accountsmgmt/v1/access_token_client.go
@@ -36,15 +36,17 @@ import (
 type AccessTokenClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewAccessTokenClient creates a new client for the 'access_token'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewAccessTokenClient(transport http.RoundTripper, path string) *AccessTokenClient {
+func NewAccessTokenClient(transport http.RoundTripper, path string, metric string) *AccessTokenClient {
 	client := new(AccessTokenClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -55,6 +57,7 @@ func (c *AccessTokenClient) Post() *AccessTokenPostRequest {
 	request := new(AccessTokenPostRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -62,6 +65,7 @@ func (c *AccessTokenClient) Post() *AccessTokenPostRequest {
 type AccessTokenPostRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -81,8 +85,7 @@ func (r *AccessTokenPostRequest) Header(name string, value interface{}) *AccessT
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *AccessTokenPostRequest) Send() (result *AccessTokenPostResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -90,7 +93,7 @@ func (r *AccessTokenPostRequest) Send() (result *AccessTokenPostResponse, err er
 // SendContext sends this request, waits for the response, and returns it.
 func (r *AccessTokenPostRequest) SendContext(ctx context.Context) (result *AccessTokenPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),

--- a/pkg/client/accountsmgmt/v1/account_client.go
+++ b/pkg/client/accountsmgmt/v1/account_client.go
@@ -38,15 +38,17 @@ import (
 type AccountClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewAccountClient creates a new client for the 'account'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewAccountClient(transport http.RoundTripper, path string) *AccountClient {
+func NewAccountClient(transport http.RoundTripper, path string, metric string) *AccountClient {
 	client := new(AccountClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -57,6 +59,7 @@ func (c *AccountClient) Get() *AccountGetRequest {
 	request := new(AccountGetRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -67,6 +70,7 @@ func (c *AccountClient) Update() *AccountUpdateRequest {
 	request := new(AccountUpdateRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -74,6 +78,7 @@ func (c *AccountClient) Update() *AccountUpdateRequest {
 type AccountGetRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -93,8 +98,7 @@ func (r *AccountGetRequest) Header(name string, value interface{}) *AccountGetRe
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *AccountGetRequest) Send() (result *AccountGetResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -102,7 +106,7 @@ func (r *AccountGetRequest) Send() (result *AccountGetResponse, err error) {
 // SendContext sends this request, waits for the response, and returns it.
 func (r *AccountGetRequest) SendContext(ctx context.Context) (result *AccountGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),
@@ -189,6 +193,7 @@ func (r *AccountGetResponse) unmarshal(reader io.Reader) error {
 type AccountUpdateRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 	body      *Account
@@ -217,8 +222,7 @@ func (r *AccountUpdateRequest) Body(value *Account) *AccountUpdateRequest {
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *AccountUpdateRequest) Send() (result *AccountUpdateResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -226,7 +230,7 @@ func (r *AccountUpdateRequest) Send() (result *AccountUpdateResponse, err error)
 // SendContext sends this request, waits for the response, and returns it.
 func (r *AccountUpdateRequest) SendContext(ctx context.Context) (result *AccountUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	buffer := new(bytes.Buffer)
 	err = r.marshal(buffer)
 	if err != nil {

--- a/pkg/client/accountsmgmt/v1/cluster_authorizations_client.go
+++ b/pkg/client/accountsmgmt/v1/cluster_authorizations_client.go
@@ -38,15 +38,17 @@ import (
 type ClusterAuthorizationsClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewClusterAuthorizationsClient creates a new client for the 'cluster_authorizations'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewClusterAuthorizationsClient(transport http.RoundTripper, path string) *ClusterAuthorizationsClient {
+func NewClusterAuthorizationsClient(transport http.RoundTripper, path string, metric string) *ClusterAuthorizationsClient {
 	client := new(ClusterAuthorizationsClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -57,6 +59,7 @@ func (c *ClusterAuthorizationsClient) Post() *ClusterAuthorizationsPostRequest {
 	request := new(ClusterAuthorizationsPostRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -64,6 +67,7 @@ func (c *ClusterAuthorizationsClient) Post() *ClusterAuthorizationsPostRequest {
 type ClusterAuthorizationsPostRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 	request   *ClusterAuthorizationRequest
@@ -92,8 +96,7 @@ func (r *ClusterAuthorizationsPostRequest) Request(value *ClusterAuthorizationRe
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *ClusterAuthorizationsPostRequest) Send() (result *ClusterAuthorizationsPostResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -101,7 +104,7 @@ func (r *ClusterAuthorizationsPostRequest) Send() (result *ClusterAuthorizations
 // SendContext sends this request, waits for the response, and returns it.
 func (r *ClusterAuthorizationsPostRequest) SendContext(ctx context.Context) (result *ClusterAuthorizationsPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	buffer := new(bytes.Buffer)
 	err = r.marshal(buffer)
 	if err != nil {

--- a/pkg/client/accountsmgmt/v1/cluster_registrations_client.go
+++ b/pkg/client/accountsmgmt/v1/cluster_registrations_client.go
@@ -38,15 +38,17 @@ import (
 type ClusterRegistrationsClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewClusterRegistrationsClient creates a new client for the 'cluster_registrations'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewClusterRegistrationsClient(transport http.RoundTripper, path string) *ClusterRegistrationsClient {
+func NewClusterRegistrationsClient(transport http.RoundTripper, path string, metric string) *ClusterRegistrationsClient {
 	client := new(ClusterRegistrationsClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -58,6 +60,7 @@ func (c *ClusterRegistrationsClient) Post() *ClusterRegistrationsPostRequest {
 	request := new(ClusterRegistrationsPostRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -65,6 +68,7 @@ func (c *ClusterRegistrationsClient) Post() *ClusterRegistrationsPostRequest {
 type ClusterRegistrationsPostRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 	request   *ClusterRegistrationRequest
@@ -93,8 +97,7 @@ func (r *ClusterRegistrationsPostRequest) Request(value *ClusterRegistrationRequ
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *ClusterRegistrationsPostRequest) Send() (result *ClusterRegistrationsPostResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -102,7 +105,7 @@ func (r *ClusterRegistrationsPostRequest) Send() (result *ClusterRegistrationsPo
 // SendContext sends this request, waits for the response, and returns it.
 func (r *ClusterRegistrationsPostRequest) SendContext(ctx context.Context) (result *ClusterRegistrationsPostResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	buffer := new(bytes.Buffer)
 	err = r.marshal(buffer)
 	if err != nil {

--- a/pkg/client/accountsmgmt/v1/current_account_client.go
+++ b/pkg/client/accountsmgmt/v1/current_account_client.go
@@ -36,15 +36,17 @@ import (
 type CurrentAccountClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewCurrentAccountClient creates a new client for the 'current_account'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewCurrentAccountClient(transport http.RoundTripper, path string) *CurrentAccountClient {
+func NewCurrentAccountClient(transport http.RoundTripper, path string, metric string) *CurrentAccountClient {
 	client := new(CurrentAccountClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -55,6 +57,7 @@ func (c *CurrentAccountClient) Get() *CurrentAccountGetRequest {
 	request := new(CurrentAccountGetRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -62,6 +65,7 @@ func (c *CurrentAccountClient) Get() *CurrentAccountGetRequest {
 type CurrentAccountGetRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -81,8 +85,7 @@ func (r *CurrentAccountGetRequest) Header(name string, value interface{}) *Curre
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *CurrentAccountGetRequest) Send() (result *CurrentAccountGetResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -90,7 +93,7 @@ func (r *CurrentAccountGetRequest) Send() (result *CurrentAccountGetResponse, er
 // SendContext sends this request, waits for the response, and returns it.
 func (r *CurrentAccountGetRequest) SendContext(ctx context.Context) (result *CurrentAccountGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),

--- a/pkg/client/accountsmgmt/v1/organization_client.go
+++ b/pkg/client/accountsmgmt/v1/organization_client.go
@@ -39,15 +39,17 @@ import (
 type OrganizationClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewOrganizationClient creates a new client for the 'organization'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewOrganizationClient(transport http.RoundTripper, path string) *OrganizationClient {
+func NewOrganizationClient(transport http.RoundTripper, path string, metric string) *OrganizationClient {
 	client := new(OrganizationClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -58,6 +60,7 @@ func (c *OrganizationClient) Get() *OrganizationGetRequest {
 	request := new(OrganizationGetRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -68,6 +71,7 @@ func (c *OrganizationClient) Update() *OrganizationUpdateRequest {
 	request := new(OrganizationUpdateRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -76,13 +80,18 @@ func (c *OrganizationClient) Update() *OrganizationUpdateRequest {
 // Reference to the service that manages the resource quotas for this
 // organization.
 func (c *OrganizationClient) ResourceQuota() *ResourceQuotasClient {
-	return NewResourceQuotasClient(c.transport, path.Join(c.path, "resource_quota"))
+	return NewResourceQuotasClient(
+		c.transport,
+		path.Join(c.path, "resource_quota"),
+		path.Join(c.metric, "resource_quota"),
+	)
 }
 
 // OrganizationGetRequest is the request for the 'get' method.
 type OrganizationGetRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -102,8 +111,7 @@ func (r *OrganizationGetRequest) Header(name string, value interface{}) *Organiz
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *OrganizationGetRequest) Send() (result *OrganizationGetResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -111,7 +119,7 @@ func (r *OrganizationGetRequest) Send() (result *OrganizationGetResponse, err er
 // SendContext sends this request, waits for the response, and returns it.
 func (r *OrganizationGetRequest) SendContext(ctx context.Context) (result *OrganizationGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),
@@ -198,6 +206,7 @@ func (r *OrganizationGetResponse) unmarshal(reader io.Reader) error {
 type OrganizationUpdateRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 	body      *Organization
@@ -226,8 +235,7 @@ func (r *OrganizationUpdateRequest) Body(value *Organization) *OrganizationUpdat
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *OrganizationUpdateRequest) Send() (result *OrganizationUpdateResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -235,7 +243,7 @@ func (r *OrganizationUpdateRequest) Send() (result *OrganizationUpdateResponse, 
 // SendContext sends this request, waits for the response, and returns it.
 func (r *OrganizationUpdateRequest) SendContext(ctx context.Context) (result *OrganizationUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	buffer := new(bytes.Buffer)
 	err = r.marshal(buffer)
 	if err != nil {

--- a/pkg/client/accountsmgmt/v1/organizations_client.go
+++ b/pkg/client/accountsmgmt/v1/organizations_client.go
@@ -39,15 +39,17 @@ import (
 type OrganizationsClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewOrganizationsClient creates a new client for the 'organizations'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewOrganizationsClient(transport http.RoundTripper, path string) *OrganizationsClient {
+func NewOrganizationsClient(transport http.RoundTripper, path string, metric string) *OrganizationsClient {
 	client := new(OrganizationsClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -58,6 +60,7 @@ func (c *OrganizationsClient) List() *OrganizationsListRequest {
 	request := new(OrganizationsListRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -68,6 +71,7 @@ func (c *OrganizationsClient) Add() *OrganizationsAddRequest {
 	request := new(OrganizationsAddRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -75,13 +79,18 @@ func (c *OrganizationsClient) Add() *OrganizationsAddRequest {
 //
 // Reference to the service that manages a specific organization.
 func (c *OrganizationsClient) Organization(id string) *OrganizationClient {
-	return NewOrganizationClient(c.transport, path.Join(c.path, id))
+	return NewOrganizationClient(
+		c.transport,
+		path.Join(c.path, id),
+		path.Join(c.metric, "-"),
+	)
 }
 
 // OrganizationsListRequest is the request for the 'list' method.
 type OrganizationsListRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 	page      *int
@@ -133,8 +142,7 @@ func (r *OrganizationsListRequest) Total(value int) *OrganizationsListRequest {
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *OrganizationsListRequest) Send() (result *OrganizationsListResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -151,7 +159,7 @@ func (r *OrganizationsListRequest) SendContext(ctx context.Context) (result *Org
 	if r.total != nil {
 		helpers.AddValue(&query, "total", *r.total)
 	}
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),
@@ -288,6 +296,7 @@ type organizationsListResponseData struct {
 type OrganizationsAddRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 	body      *Organization
@@ -316,8 +325,7 @@ func (r *OrganizationsAddRequest) Body(value *Organization) *OrganizationsAddReq
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *OrganizationsAddRequest) Send() (result *OrganizationsAddResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -325,7 +333,7 @@ func (r *OrganizationsAddRequest) Send() (result *OrganizationsAddResponse, err 
 // SendContext sends this request, waits for the response, and returns it.
 func (r *OrganizationsAddRequest) SendContext(ctx context.Context) (result *OrganizationsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	buffer := new(bytes.Buffer)
 	err = r.marshal(buffer)
 	if err != nil {

--- a/pkg/client/accountsmgmt/v1/permission_client.go
+++ b/pkg/client/accountsmgmt/v1/permission_client.go
@@ -36,15 +36,17 @@ import (
 type PermissionClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewPermissionClient creates a new client for the 'permission'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewPermissionClient(transport http.RoundTripper, path string) *PermissionClient {
+func NewPermissionClient(transport http.RoundTripper, path string, metric string) *PermissionClient {
 	client := new(PermissionClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -55,6 +57,7 @@ func (c *PermissionClient) Get() *PermissionGetRequest {
 	request := new(PermissionGetRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -65,6 +68,7 @@ func (c *PermissionClient) Delete() *PermissionDeleteRequest {
 	request := new(PermissionDeleteRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -72,6 +76,7 @@ func (c *PermissionClient) Delete() *PermissionDeleteRequest {
 type PermissionGetRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -91,8 +96,7 @@ func (r *PermissionGetRequest) Header(name string, value interface{}) *Permissio
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *PermissionGetRequest) Send() (result *PermissionGetResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -100,7 +104,7 @@ func (r *PermissionGetRequest) Send() (result *PermissionGetResponse, err error)
 // SendContext sends this request, waits for the response, and returns it.
 func (r *PermissionGetRequest) SendContext(ctx context.Context) (result *PermissionGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),
@@ -187,6 +191,7 @@ func (r *PermissionGetResponse) unmarshal(reader io.Reader) error {
 type PermissionDeleteRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -206,8 +211,7 @@ func (r *PermissionDeleteRequest) Header(name string, value interface{}) *Permis
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *PermissionDeleteRequest) Send() (result *PermissionDeleteResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -215,7 +219,7 @@ func (r *PermissionDeleteRequest) Send() (result *PermissionDeleteResponse, err 
 // SendContext sends this request, waits for the response, and returns it.
 func (r *PermissionDeleteRequest) SendContext(ctx context.Context) (result *PermissionDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),

--- a/pkg/client/accountsmgmt/v1/registries_client.go
+++ b/pkg/client/accountsmgmt/v1/registries_client.go
@@ -37,15 +37,17 @@ import (
 type RegistriesClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewRegistriesClient creates a new client for the 'registries'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewRegistriesClient(transport http.RoundTripper, path string) *RegistriesClient {
+func NewRegistriesClient(transport http.RoundTripper, path string, metric string) *RegistriesClient {
 	client := new(RegistriesClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -56,6 +58,7 @@ func (c *RegistriesClient) List() *RegistriesListRequest {
 	request := new(RegistriesListRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -63,13 +66,18 @@ func (c *RegistriesClient) List() *RegistriesListRequest {
 //
 // Reference to the service that manages a specific registry.
 func (c *RegistriesClient) Registry(id string) *RegistryClient {
-	return NewRegistryClient(c.transport, path.Join(c.path, id))
+	return NewRegistryClient(
+		c.transport,
+		path.Join(c.path, id),
+		path.Join(c.metric, "-"),
+	)
 }
 
 // RegistriesListRequest is the request for the 'list' method.
 type RegistriesListRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 	page      *int
@@ -121,8 +129,7 @@ func (r *RegistriesListRequest) Total(value int) *RegistriesListRequest {
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *RegistriesListRequest) Send() (result *RegistriesListResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -139,7 +146,7 @@ func (r *RegistriesListRequest) SendContext(ctx context.Context) (result *Regist
 	if r.total != nil {
 		helpers.AddValue(&query, "total", *r.total)
 	}
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),

--- a/pkg/client/accountsmgmt/v1/registry_client.go
+++ b/pkg/client/accountsmgmt/v1/registry_client.go
@@ -36,15 +36,17 @@ import (
 type RegistryClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewRegistryClient creates a new client for the 'registry'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewRegistryClient(transport http.RoundTripper, path string) *RegistryClient {
+func NewRegistryClient(transport http.RoundTripper, path string, metric string) *RegistryClient {
 	client := new(RegistryClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -55,6 +57,7 @@ func (c *RegistryClient) Get() *RegistryGetRequest {
 	request := new(RegistryGetRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -62,6 +65,7 @@ func (c *RegistryClient) Get() *RegistryGetRequest {
 type RegistryGetRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -81,8 +85,7 @@ func (r *RegistryGetRequest) Header(name string, value interface{}) *RegistryGet
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *RegistryGetRequest) Send() (result *RegistryGetResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -90,7 +93,7 @@ func (r *RegistryGetRequest) Send() (result *RegistryGetResponse, err error) {
 // SendContext sends this request, waits for the response, and returns it.
 func (r *RegistryGetRequest) SendContext(ctx context.Context) (result *RegistryGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),

--- a/pkg/client/accountsmgmt/v1/registry_credential_client.go
+++ b/pkg/client/accountsmgmt/v1/registry_credential_client.go
@@ -36,15 +36,17 @@ import (
 type RegistryCredentialClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewRegistryCredentialClient creates a new client for the 'registry_credential'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewRegistryCredentialClient(transport http.RoundTripper, path string) *RegistryCredentialClient {
+func NewRegistryCredentialClient(transport http.RoundTripper, path string, metric string) *RegistryCredentialClient {
 	client := new(RegistryCredentialClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -55,6 +57,7 @@ func (c *RegistryCredentialClient) Get() *RegistryCredentialGetRequest {
 	request := new(RegistryCredentialGetRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -62,6 +65,7 @@ func (c *RegistryCredentialClient) Get() *RegistryCredentialGetRequest {
 type RegistryCredentialGetRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -81,8 +85,7 @@ func (r *RegistryCredentialGetRequest) Header(name string, value interface{}) *R
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *RegistryCredentialGetRequest) Send() (result *RegistryCredentialGetResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -90,7 +93,7 @@ func (r *RegistryCredentialGetRequest) Send() (result *RegistryCredentialGetResp
 // SendContext sends this request, waits for the response, and returns it.
 func (r *RegistryCredentialGetRequest) SendContext(ctx context.Context) (result *RegistryCredentialGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),

--- a/pkg/client/accountsmgmt/v1/registry_credentials_client.go
+++ b/pkg/client/accountsmgmt/v1/registry_credentials_client.go
@@ -39,15 +39,17 @@ import (
 type RegistryCredentialsClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewRegistryCredentialsClient creates a new client for the 'registry_credentials'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewRegistryCredentialsClient(transport http.RoundTripper, path string) *RegistryCredentialsClient {
+func NewRegistryCredentialsClient(transport http.RoundTripper, path string, metric string) *RegistryCredentialsClient {
 	client := new(RegistryCredentialsClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -58,6 +60,7 @@ func (c *RegistryCredentialsClient) List() *RegistryCredentialsListRequest {
 	request := new(RegistryCredentialsListRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -68,6 +71,7 @@ func (c *RegistryCredentialsClient) Add() *RegistryCredentialsAddRequest {
 	request := new(RegistryCredentialsAddRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -75,13 +79,18 @@ func (c *RegistryCredentialsClient) Add() *RegistryCredentialsAddRequest {
 //
 // Reference to the service that manages an specific registry credential.
 func (c *RegistryCredentialsClient) RegistryCredential(id string) *RegistryCredentialClient {
-	return NewRegistryCredentialClient(c.transport, path.Join(c.path, id))
+	return NewRegistryCredentialClient(
+		c.transport,
+		path.Join(c.path, id),
+		path.Join(c.metric, "-"),
+	)
 }
 
 // RegistryCredentialsListRequest is the request for the 'list' method.
 type RegistryCredentialsListRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 	page      *int
@@ -133,8 +142,7 @@ func (r *RegistryCredentialsListRequest) Total(value int) *RegistryCredentialsLi
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *RegistryCredentialsListRequest) Send() (result *RegistryCredentialsListResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -151,7 +159,7 @@ func (r *RegistryCredentialsListRequest) SendContext(ctx context.Context) (resul
 	if r.total != nil {
 		helpers.AddValue(&query, "total", *r.total)
 	}
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),
@@ -288,6 +296,7 @@ type registryCredentialsListResponseData struct {
 type RegistryCredentialsAddRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 	body      *RegistryCredential
@@ -316,8 +325,7 @@ func (r *RegistryCredentialsAddRequest) Body(value *RegistryCredential) *Registr
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *RegistryCredentialsAddRequest) Send() (result *RegistryCredentialsAddResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -325,7 +333,7 @@ func (r *RegistryCredentialsAddRequest) Send() (result *RegistryCredentialsAddRe
 // SendContext sends this request, waits for the response, and returns it.
 func (r *RegistryCredentialsAddRequest) SendContext(ctx context.Context) (result *RegistryCredentialsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	buffer := new(bytes.Buffer)
 	err = r.marshal(buffer)
 	if err != nil {

--- a/pkg/client/accountsmgmt/v1/resource_quota_client.go
+++ b/pkg/client/accountsmgmt/v1/resource_quota_client.go
@@ -38,15 +38,17 @@ import (
 type ResourceQuotaClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewResourceQuotaClient creates a new client for the 'resource_quota'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewResourceQuotaClient(transport http.RoundTripper, path string) *ResourceQuotaClient {
+func NewResourceQuotaClient(transport http.RoundTripper, path string, metric string) *ResourceQuotaClient {
 	client := new(ResourceQuotaClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -57,6 +59,7 @@ func (c *ResourceQuotaClient) Get() *ResourceQuotaGetRequest {
 	request := new(ResourceQuotaGetRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -67,6 +70,7 @@ func (c *ResourceQuotaClient) Update() *ResourceQuotaUpdateRequest {
 	request := new(ResourceQuotaUpdateRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -74,6 +78,7 @@ func (c *ResourceQuotaClient) Update() *ResourceQuotaUpdateRequest {
 type ResourceQuotaGetRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -93,8 +98,7 @@ func (r *ResourceQuotaGetRequest) Header(name string, value interface{}) *Resour
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *ResourceQuotaGetRequest) Send() (result *ResourceQuotaGetResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -102,7 +106,7 @@ func (r *ResourceQuotaGetRequest) Send() (result *ResourceQuotaGetResponse, err 
 // SendContext sends this request, waits for the response, and returns it.
 func (r *ResourceQuotaGetRequest) SendContext(ctx context.Context) (result *ResourceQuotaGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),
@@ -189,6 +193,7 @@ func (r *ResourceQuotaGetResponse) unmarshal(reader io.Reader) error {
 type ResourceQuotaUpdateRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 	body      *ResourceQuota
@@ -217,8 +222,7 @@ func (r *ResourceQuotaUpdateRequest) Body(value *ResourceQuota) *ResourceQuotaUp
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *ResourceQuotaUpdateRequest) Send() (result *ResourceQuotaUpdateResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -226,7 +230,7 @@ func (r *ResourceQuotaUpdateRequest) Send() (result *ResourceQuotaUpdateResponse
 // SendContext sends this request, waits for the response, and returns it.
 func (r *ResourceQuotaUpdateRequest) SendContext(ctx context.Context) (result *ResourceQuotaUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	buffer := new(bytes.Buffer)
 	err = r.marshal(buffer)
 	if err != nil {

--- a/pkg/client/accountsmgmt/v1/resource_quotas_client.go
+++ b/pkg/client/accountsmgmt/v1/resource_quotas_client.go
@@ -39,15 +39,17 @@ import (
 type ResourceQuotasClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewResourceQuotasClient creates a new client for the 'resource_quotas'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewResourceQuotasClient(transport http.RoundTripper, path string) *ResourceQuotasClient {
+func NewResourceQuotasClient(transport http.RoundTripper, path string, metric string) *ResourceQuotasClient {
 	client := new(ResourceQuotasClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -58,6 +60,7 @@ func (c *ResourceQuotasClient) List() *ResourceQuotasListRequest {
 	request := new(ResourceQuotasListRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -68,6 +71,7 @@ func (c *ResourceQuotasClient) Add() *ResourceQuotasAddRequest {
 	request := new(ResourceQuotasAddRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -75,13 +79,18 @@ func (c *ResourceQuotasClient) Add() *ResourceQuotasAddRequest {
 //
 // Reference to the service that manages an specific resource quota.
 func (c *ResourceQuotasClient) ResourceQuota(id string) *ResourceQuotaClient {
-	return NewResourceQuotaClient(c.transport, path.Join(c.path, id))
+	return NewResourceQuotaClient(
+		c.transport,
+		path.Join(c.path, id),
+		path.Join(c.metric, "-"),
+	)
 }
 
 // ResourceQuotasListRequest is the request for the 'list' method.
 type ResourceQuotasListRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 	page      *int
@@ -133,8 +142,7 @@ func (r *ResourceQuotasListRequest) Total(value int) *ResourceQuotasListRequest 
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *ResourceQuotasListRequest) Send() (result *ResourceQuotasListResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -151,7 +159,7 @@ func (r *ResourceQuotasListRequest) SendContext(ctx context.Context) (result *Re
 	if r.total != nil {
 		helpers.AddValue(&query, "total", *r.total)
 	}
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),
@@ -288,6 +296,7 @@ type resourceQuotasListResponseData struct {
 type ResourceQuotasAddRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 	body      *ResourceQuota
@@ -316,8 +325,7 @@ func (r *ResourceQuotasAddRequest) Body(value *ResourceQuota) *ResourceQuotasAdd
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *ResourceQuotasAddRequest) Send() (result *ResourceQuotasAddResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -325,7 +333,7 @@ func (r *ResourceQuotasAddRequest) Send() (result *ResourceQuotasAddResponse, er
 // SendContext sends this request, waits for the response, and returns it.
 func (r *ResourceQuotasAddRequest) SendContext(ctx context.Context) (result *ResourceQuotasAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	buffer := new(bytes.Buffer)
 	err = r.marshal(buffer)
 	if err != nil {

--- a/pkg/client/accountsmgmt/v1/role_binding_client.go
+++ b/pkg/client/accountsmgmt/v1/role_binding_client.go
@@ -36,15 +36,17 @@ import (
 type RoleBindingClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewRoleBindingClient creates a new client for the 'role_binding'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewRoleBindingClient(transport http.RoundTripper, path string) *RoleBindingClient {
+func NewRoleBindingClient(transport http.RoundTripper, path string, metric string) *RoleBindingClient {
 	client := new(RoleBindingClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -55,6 +57,7 @@ func (c *RoleBindingClient) Get() *RoleBindingGetRequest {
 	request := new(RoleBindingGetRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -65,6 +68,7 @@ func (c *RoleBindingClient) Delete() *RoleBindingDeleteRequest {
 	request := new(RoleBindingDeleteRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -72,6 +76,7 @@ func (c *RoleBindingClient) Delete() *RoleBindingDeleteRequest {
 type RoleBindingGetRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -91,8 +96,7 @@ func (r *RoleBindingGetRequest) Header(name string, value interface{}) *RoleBind
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *RoleBindingGetRequest) Send() (result *RoleBindingGetResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -100,7 +104,7 @@ func (r *RoleBindingGetRequest) Send() (result *RoleBindingGetResponse, err erro
 // SendContext sends this request, waits for the response, and returns it.
 func (r *RoleBindingGetRequest) SendContext(ctx context.Context) (result *RoleBindingGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),
@@ -187,6 +191,7 @@ func (r *RoleBindingGetResponse) unmarshal(reader io.Reader) error {
 type RoleBindingDeleteRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -206,8 +211,7 @@ func (r *RoleBindingDeleteRequest) Header(name string, value interface{}) *RoleB
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *RoleBindingDeleteRequest) Send() (result *RoleBindingDeleteResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -215,7 +219,7 @@ func (r *RoleBindingDeleteRequest) Send() (result *RoleBindingDeleteResponse, er
 // SendContext sends this request, waits for the response, and returns it.
 func (r *RoleBindingDeleteRequest) SendContext(ctx context.Context) (result *RoleBindingDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),

--- a/pkg/client/accountsmgmt/v1/role_bindings_client.go
+++ b/pkg/client/accountsmgmt/v1/role_bindings_client.go
@@ -39,15 +39,17 @@ import (
 type RoleBindingsClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewRoleBindingsClient creates a new client for the 'role_bindings'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewRoleBindingsClient(transport http.RoundTripper, path string) *RoleBindingsClient {
+func NewRoleBindingsClient(transport http.RoundTripper, path string, metric string) *RoleBindingsClient {
 	client := new(RoleBindingsClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -58,6 +60,7 @@ func (c *RoleBindingsClient) List() *RoleBindingsListRequest {
 	request := new(RoleBindingsListRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -68,6 +71,7 @@ func (c *RoleBindingsClient) Add() *RoleBindingsAddRequest {
 	request := new(RoleBindingsAddRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -75,13 +79,18 @@ func (c *RoleBindingsClient) Add() *RoleBindingsAddRequest {
 //
 // Reference to the service that manages a specific role binding.
 func (c *RoleBindingsClient) RoleBinding(id string) *RoleBindingClient {
-	return NewRoleBindingClient(c.transport, path.Join(c.path, id))
+	return NewRoleBindingClient(
+		c.transport,
+		path.Join(c.path, id),
+		path.Join(c.metric, "-"),
+	)
 }
 
 // RoleBindingsListRequest is the request for the 'list' method.
 type RoleBindingsListRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 	page      *int
@@ -133,8 +142,7 @@ func (r *RoleBindingsListRequest) Total(value int) *RoleBindingsListRequest {
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *RoleBindingsListRequest) Send() (result *RoleBindingsListResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -151,7 +159,7 @@ func (r *RoleBindingsListRequest) SendContext(ctx context.Context) (result *Role
 	if r.total != nil {
 		helpers.AddValue(&query, "total", *r.total)
 	}
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),
@@ -288,6 +296,7 @@ type roleBindingsListResponseData struct {
 type RoleBindingsAddRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 	body      *RoleBinding
@@ -316,8 +325,7 @@ func (r *RoleBindingsAddRequest) Body(value *RoleBinding) *RoleBindingsAddReques
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *RoleBindingsAddRequest) Send() (result *RoleBindingsAddResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -325,7 +333,7 @@ func (r *RoleBindingsAddRequest) Send() (result *RoleBindingsAddResponse, err er
 // SendContext sends this request, waits for the response, and returns it.
 func (r *RoleBindingsAddRequest) SendContext(ctx context.Context) (result *RoleBindingsAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	buffer := new(bytes.Buffer)
 	err = r.marshal(buffer)
 	if err != nil {

--- a/pkg/client/accountsmgmt/v1/role_client.go
+++ b/pkg/client/accountsmgmt/v1/role_client.go
@@ -38,15 +38,17 @@ import (
 type RoleClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewRoleClient creates a new client for the 'role'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewRoleClient(transport http.RoundTripper, path string) *RoleClient {
+func NewRoleClient(transport http.RoundTripper, path string, metric string) *RoleClient {
 	client := new(RoleClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -57,6 +59,7 @@ func (c *RoleClient) Get() *RoleGetRequest {
 	request := new(RoleGetRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -67,6 +70,7 @@ func (c *RoleClient) Update() *RoleUpdateRequest {
 	request := new(RoleUpdateRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -77,6 +81,7 @@ func (c *RoleClient) Delete() *RoleDeleteRequest {
 	request := new(RoleDeleteRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -84,6 +89,7 @@ func (c *RoleClient) Delete() *RoleDeleteRequest {
 type RoleGetRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -103,8 +109,7 @@ func (r *RoleGetRequest) Header(name string, value interface{}) *RoleGetRequest 
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *RoleGetRequest) Send() (result *RoleGetResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -112,7 +117,7 @@ func (r *RoleGetRequest) Send() (result *RoleGetResponse, err error) {
 // SendContext sends this request, waits for the response, and returns it.
 func (r *RoleGetRequest) SendContext(ctx context.Context) (result *RoleGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),
@@ -199,6 +204,7 @@ func (r *RoleGetResponse) unmarshal(reader io.Reader) error {
 type RoleUpdateRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 	body      *Role
@@ -227,8 +233,7 @@ func (r *RoleUpdateRequest) Body(value *Role) *RoleUpdateRequest {
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *RoleUpdateRequest) Send() (result *RoleUpdateResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -236,7 +241,7 @@ func (r *RoleUpdateRequest) Send() (result *RoleUpdateResponse, err error) {
 // SendContext sends this request, waits for the response, and returns it.
 func (r *RoleUpdateRequest) SendContext(ctx context.Context) (result *RoleUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	buffer := new(bytes.Buffer)
 	err = r.marshal(buffer)
 	if err != nil {
@@ -342,6 +347,7 @@ func (r *RoleUpdateResponse) unmarshal(reader io.Reader) error {
 type RoleDeleteRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -361,8 +367,7 @@ func (r *RoleDeleteRequest) Header(name string, value interface{}) *RoleDeleteRe
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *RoleDeleteRequest) Send() (result *RoleDeleteResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -370,7 +375,7 @@ func (r *RoleDeleteRequest) Send() (result *RoleDeleteResponse, err error) {
 // SendContext sends this request, waits for the response, and returns it.
 func (r *RoleDeleteRequest) SendContext(ctx context.Context) (result *RoleDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),

--- a/pkg/client/accountsmgmt/v1/roles_client.go
+++ b/pkg/client/accountsmgmt/v1/roles_client.go
@@ -39,15 +39,17 @@ import (
 type RolesClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewRolesClient creates a new client for the 'roles'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewRolesClient(transport http.RoundTripper, path string) *RolesClient {
+func NewRolesClient(transport http.RoundTripper, path string, metric string) *RolesClient {
 	client := new(RolesClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -58,6 +60,7 @@ func (c *RolesClient) List() *RolesListRequest {
 	request := new(RolesListRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -68,6 +71,7 @@ func (c *RolesClient) Add() *RolesAddRequest {
 	request := new(RolesAddRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -75,13 +79,18 @@ func (c *RolesClient) Add() *RolesAddRequest {
 //
 // Reference to the service that manages a specific role.
 func (c *RolesClient) Role(id string) *RoleClient {
-	return NewRoleClient(c.transport, path.Join(c.path, id))
+	return NewRoleClient(
+		c.transport,
+		path.Join(c.path, id),
+		path.Join(c.metric, "-"),
+	)
 }
 
 // RolesListRequest is the request for the 'list' method.
 type RolesListRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 	page      *int
@@ -133,8 +142,7 @@ func (r *RolesListRequest) Total(value int) *RolesListRequest {
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *RolesListRequest) Send() (result *RolesListResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -151,7 +159,7 @@ func (r *RolesListRequest) SendContext(ctx context.Context) (result *RolesListRe
 	if r.total != nil {
 		helpers.AddValue(&query, "total", *r.total)
 	}
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),
@@ -288,6 +296,7 @@ type rolesListResponseData struct {
 type RolesAddRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 	body      *Role
@@ -316,8 +325,7 @@ func (r *RolesAddRequest) Body(value *Role) *RolesAddRequest {
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *RolesAddRequest) Send() (result *RolesAddResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -325,7 +333,7 @@ func (r *RolesAddRequest) Send() (result *RolesAddResponse, err error) {
 // SendContext sends this request, waits for the response, and returns it.
 func (r *RolesAddRequest) SendContext(ctx context.Context) (result *RolesAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	buffer := new(bytes.Buffer)
 	err = r.marshal(buffer)
 	if err != nil {

--- a/pkg/client/accountsmgmt/v1/root_client.go
+++ b/pkg/client/accountsmgmt/v1/root_client.go
@@ -30,15 +30,17 @@ import (
 type RootClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewRootClient creates a new client for the 'root'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewRootClient(transport http.RoundTripper, path string) *RootClient {
+func NewRootClient(transport http.RoundTripper, path string, metric string) *RootClient {
 	client := new(RootClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -46,7 +48,11 @@ func NewRootClient(transport http.RoundTripper, path string) *RootClient {
 //
 // Reference to the resource that manages the collection of accounts.
 func (c *RootClient) Accounts() *AccountsClient {
-	return NewAccountsClient(c.transport, path.Join(c.path, "accounts"))
+	return NewAccountsClient(
+		c.transport,
+		path.Join(c.path, "accounts"),
+		path.Join(c.metric, "accounts"),
+	)
 }
 
 // CurrentAccount returns the target 'current_account' resource.
@@ -54,7 +60,11 @@ func (c *RootClient) Accounts() *AccountsClient {
 // Reference to the resource that manages the current authenticated
 // acount.
 func (c *RootClient) CurrentAccount() *CurrentAccountClient {
-	return NewCurrentAccountClient(c.transport, path.Join(c.path, "current_account"))
+	return NewCurrentAccountClient(
+		c.transport,
+		path.Join(c.path, "current_account"),
+		path.Join(c.metric, "current_account"),
+	)
 }
 
 // Organizations returns the target 'organizations' resource.
@@ -62,28 +72,44 @@ func (c *RootClient) CurrentAccount() *CurrentAccountClient {
 // Reference to the resource that manages the collection of
 // organizations.
 func (c *RootClient) Organizations() *OrganizationsClient {
-	return NewOrganizationsClient(c.transport, path.Join(c.path, "organizations"))
+	return NewOrganizationsClient(
+		c.transport,
+		path.Join(c.path, "organizations"),
+		path.Join(c.metric, "organizations"),
+	)
 }
 
 // AccessToken returns the target 'access_token' resource.
 //
 // Reference to the resource that manages generates access tokens.
 func (c *RootClient) AccessToken() *AccessTokenClient {
-	return NewAccessTokenClient(c.transport, path.Join(c.path, "access_token"))
+	return NewAccessTokenClient(
+		c.transport,
+		path.Join(c.path, "access_token"),
+		path.Join(c.metric, "access_token"),
+	)
 }
 
 // Permissions returns the target 'permissions' resource.
 //
 // Reference to the resource that manages the collection of permissions.
 func (c *RootClient) Permissions() *PermissionsClient {
-	return NewPermissionsClient(c.transport, path.Join(c.path, "permissions"))
+	return NewPermissionsClient(
+		c.transport,
+		path.Join(c.path, "permissions"),
+		path.Join(c.metric, "permissions"),
+	)
 }
 
 // Registries returns the target 'registries' resource.
 //
 // Reference to the resource that manages the collection of registries.
 func (c *RootClient) Registries() *RegistriesClient {
-	return NewRegistriesClient(c.transport, path.Join(c.path, "registries"))
+	return NewRegistriesClient(
+		c.transport,
+		path.Join(c.path, "registries"),
+		path.Join(c.metric, "registries"),
+	)
 }
 
 // RegistryCredentials returns the target 'registry_credentials' resource.
@@ -91,28 +117,44 @@ func (c *RootClient) Registries() *RegistriesClient {
 // Reference to the resource that manages the collection of registry
 // credentials.
 func (c *RootClient) RegistryCredentials() *RegistryCredentialsClient {
-	return NewRegistryCredentialsClient(c.transport, path.Join(c.path, "registry_credentials"))
+	return NewRegistryCredentialsClient(
+		c.transport,
+		path.Join(c.path, "registry_credentials"),
+		path.Join(c.metric, "registry_credentials"),
+	)
 }
 
 // ClusterAuthorizations returns the target 'cluster_authorizations' resource.
 //
 // Reference to the resource that manages cluster authorizations.
 func (c *RootClient) ClusterAuthorizations() *ClusterAuthorizationsClient {
-	return NewClusterAuthorizationsClient(c.transport, path.Join(c.path, "cluster_authorizations"))
+	return NewClusterAuthorizationsClient(
+		c.transport,
+		path.Join(c.path, "cluster_authorizations"),
+		path.Join(c.metric, "cluster_authorizations"),
+	)
 }
 
 // ClusterRegistrations returns the target 'cluster_registrations' resource.
 //
 // Reference to the resource that manages cluster registrations.
 func (c *RootClient) ClusterRegistrations() *ClusterRegistrationsClient {
-	return NewClusterRegistrationsClient(c.transport, path.Join(c.path, "cluster_registrations"))
+	return NewClusterRegistrationsClient(
+		c.transport,
+		path.Join(c.path, "cluster_registrations"),
+		path.Join(c.metric, "cluster_registrations"),
+	)
 }
 
 // Roles returns the target 'roles' resource.
 //
 // Reference to the resource that manages the collection of roles.
 func (c *RootClient) Roles() *RolesClient {
-	return NewRolesClient(c.transport, path.Join(c.path, "roles"))
+	return NewRolesClient(
+		c.transport,
+		path.Join(c.path, "roles"),
+		path.Join(c.metric, "roles"),
+	)
 }
 
 // RoleBindings returns the target 'role_bindings' resource.
@@ -120,7 +162,11 @@ func (c *RootClient) Roles() *RolesClient {
 // Reference to the resource that manages the collection of role
 // bindings.
 func (c *RootClient) RoleBindings() *RoleBindingsClient {
-	return NewRoleBindingsClient(c.transport, path.Join(c.path, "role_bindings"))
+	return NewRoleBindingsClient(
+		c.transport,
+		path.Join(c.path, "role_bindings"),
+		path.Join(c.metric, "role_bindings"),
+	)
 }
 
 // Subscriptions returns the target 'subscriptions' resource.
@@ -128,5 +174,9 @@ func (c *RootClient) RoleBindings() *RoleBindingsClient {
 // Reference to the resource that manages the collection of
 // subscriptions.
 func (c *RootClient) Subscriptions() *SubscriptionsClient {
-	return NewSubscriptionsClient(c.transport, path.Join(c.path, "subscriptions"))
+	return NewSubscriptionsClient(
+		c.transport,
+		path.Join(c.path, "subscriptions"),
+		path.Join(c.metric, "subscriptions"),
+	)
 }

--- a/pkg/client/accountsmgmt/v1/subscription_client.go
+++ b/pkg/client/accountsmgmt/v1/subscription_client.go
@@ -36,15 +36,17 @@ import (
 type SubscriptionClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewSubscriptionClient creates a new client for the 'subscription'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewSubscriptionClient(transport http.RoundTripper, path string) *SubscriptionClient {
+func NewSubscriptionClient(transport http.RoundTripper, path string, metric string) *SubscriptionClient {
 	client := new(SubscriptionClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -55,6 +57,7 @@ func (c *SubscriptionClient) Get() *SubscriptionGetRequest {
 	request := new(SubscriptionGetRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -65,6 +68,7 @@ func (c *SubscriptionClient) Delete() *SubscriptionDeleteRequest {
 	request := new(SubscriptionDeleteRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -72,6 +76,7 @@ func (c *SubscriptionClient) Delete() *SubscriptionDeleteRequest {
 type SubscriptionGetRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -91,8 +96,7 @@ func (r *SubscriptionGetRequest) Header(name string, value interface{}) *Subscri
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *SubscriptionGetRequest) Send() (result *SubscriptionGetResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -100,7 +104,7 @@ func (r *SubscriptionGetRequest) Send() (result *SubscriptionGetResponse, err er
 // SendContext sends this request, waits for the response, and returns it.
 func (r *SubscriptionGetRequest) SendContext(ctx context.Context) (result *SubscriptionGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),
@@ -187,6 +191,7 @@ func (r *SubscriptionGetResponse) unmarshal(reader io.Reader) error {
 type SubscriptionDeleteRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -206,8 +211,7 @@ func (r *SubscriptionDeleteRequest) Header(name string, value interface{}) *Subs
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *SubscriptionDeleteRequest) Send() (result *SubscriptionDeleteResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -215,7 +219,7 @@ func (r *SubscriptionDeleteRequest) Send() (result *SubscriptionDeleteResponse, 
 // SendContext sends this request, waits for the response, and returns it.
 func (r *SubscriptionDeleteRequest) SendContext(ctx context.Context) (result *SubscriptionDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),

--- a/pkg/client/clustersmgmt/client.go
+++ b/pkg/client/clustersmgmt/client.go
@@ -30,14 +30,16 @@ import (
 type Client struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewClient creates a new client for the service 'clusters_mgmt' using the
 // given transport to send the requests and receive the responses.
-func NewClient(transport http.RoundTripper, path string) *Client {
+func NewClient(transport http.RoundTripper, path string, metric string) *Client {
 	client := new(Client)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -46,5 +48,6 @@ func (c *Client) V1() *v1.RootClient {
 	return v1.NewRootClient(
 		c.transport,
 		path.Join(c.path, "v1"),
+		path.Join(c.metric, "v1"),
 	)
 }

--- a/pkg/client/clustersmgmt/v1/cluster_client.go
+++ b/pkg/client/clustersmgmt/v1/cluster_client.go
@@ -39,15 +39,17 @@ import (
 type ClusterClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewClusterClient creates a new client for the 'cluster'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewClusterClient(transport http.RoundTripper, path string) *ClusterClient {
+func NewClusterClient(transport http.RoundTripper, path string, metric string) *ClusterClient {
 	client := new(ClusterClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -58,6 +60,7 @@ func (c *ClusterClient) Get() *ClusterGetRequest {
 	request := new(ClusterGetRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -68,6 +71,7 @@ func (c *ClusterClient) Update() *ClusterUpdateRequest {
 	request := new(ClusterUpdateRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -78,6 +82,7 @@ func (c *ClusterClient) Delete() *ClusterDeleteRequest {
 	request := new(ClusterDeleteRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -85,41 +90,62 @@ func (c *ClusterClient) Delete() *ClusterDeleteRequest {
 //
 // Reference to the resource that manages the detailed status of the cluster.
 func (c *ClusterClient) Status() *ClusterStatusClient {
-	return NewClusterStatusClient(c.transport, path.Join(c.path, "status"))
+	return NewClusterStatusClient(
+		c.transport,
+		path.Join(c.path, "status"),
+		path.Join(c.metric, "status"),
+	)
 }
 
 // Credentials returns the target 'credentials' resource.
 //
 // Reference to the resource that manages the credentials of the cluster.
 func (c *ClusterClient) Credentials() *CredentialsClient {
-	return NewCredentialsClient(c.transport, path.Join(c.path, "credentials"))
+	return NewCredentialsClient(
+		c.transport,
+		path.Join(c.path, "credentials"),
+		path.Join(c.metric, "credentials"),
+	)
 }
 
 // Logs returns the target 'logs' resource.
 //
 // Reference to the resource that manages the collection of logs of the cluster.
 func (c *ClusterClient) Logs() *LogsClient {
-	return NewLogsClient(c.transport, path.Join(c.path, "logs"))
+	return NewLogsClient(
+		c.transport,
+		path.Join(c.path, "logs"),
+		path.Join(c.metric, "logs"),
+	)
 }
 
 // Groups returns the target 'groups' resource.
 //
 // Reference to the resource that manages the collection of groups.
 func (c *ClusterClient) Groups() *GroupsClient {
-	return NewGroupsClient(c.transport, path.Join(c.path, "groups"))
+	return NewGroupsClient(
+		c.transport,
+		path.Join(c.path, "groups"),
+		path.Join(c.metric, "groups"),
+	)
 }
 
 // IdentityProviders returns the target 'identity_providers' resource.
 //
 // Reference to the resource that manages the collection of identity providers.
 func (c *ClusterClient) IdentityProviders() *IdentityProvidersClient {
-	return NewIdentityProvidersClient(c.transport, path.Join(c.path, "identity_providers"))
+	return NewIdentityProvidersClient(
+		c.transport,
+		path.Join(c.path, "identity_providers"),
+		path.Join(c.metric, "identity_providers"),
+	)
 }
 
 // ClusterGetRequest is the request for the 'get' method.
 type ClusterGetRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -139,8 +165,7 @@ func (r *ClusterGetRequest) Header(name string, value interface{}) *ClusterGetRe
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *ClusterGetRequest) Send() (result *ClusterGetResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -148,7 +173,7 @@ func (r *ClusterGetRequest) Send() (result *ClusterGetResponse, err error) {
 // SendContext sends this request, waits for the response, and returns it.
 func (r *ClusterGetRequest) SendContext(ctx context.Context) (result *ClusterGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),
@@ -235,6 +260,7 @@ func (r *ClusterGetResponse) unmarshal(reader io.Reader) error {
 type ClusterUpdateRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 	body      *Cluster
@@ -263,8 +289,7 @@ func (r *ClusterUpdateRequest) Body(value *Cluster) *ClusterUpdateRequest {
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *ClusterUpdateRequest) Send() (result *ClusterUpdateResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -272,7 +297,7 @@ func (r *ClusterUpdateRequest) Send() (result *ClusterUpdateResponse, err error)
 // SendContext sends this request, waits for the response, and returns it.
 func (r *ClusterUpdateRequest) SendContext(ctx context.Context) (result *ClusterUpdateResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	buffer := new(bytes.Buffer)
 	err = r.marshal(buffer)
 	if err != nil {
@@ -378,6 +403,7 @@ func (r *ClusterUpdateResponse) unmarshal(reader io.Reader) error {
 type ClusterDeleteRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -397,8 +423,7 @@ func (r *ClusterDeleteRequest) Header(name string, value interface{}) *ClusterDe
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *ClusterDeleteRequest) Send() (result *ClusterDeleteResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -406,7 +431,7 @@ func (r *ClusterDeleteRequest) Send() (result *ClusterDeleteResponse, err error)
 // SendContext sends this request, waits for the response, and returns it.
 func (r *ClusterDeleteRequest) SendContext(ctx context.Context) (result *ClusterDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),

--- a/pkg/client/clustersmgmt/v1/cluster_status_client.go
+++ b/pkg/client/clustersmgmt/v1/cluster_status_client.go
@@ -36,15 +36,17 @@ import (
 type ClusterStatusClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewClusterStatusClient creates a new client for the 'cluster_status'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewClusterStatusClient(transport http.RoundTripper, path string) *ClusterStatusClient {
+func NewClusterStatusClient(transport http.RoundTripper, path string, metric string) *ClusterStatusClient {
 	client := new(ClusterStatusClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -55,6 +57,7 @@ func (c *ClusterStatusClient) Get() *ClusterStatusGetRequest {
 	request := new(ClusterStatusGetRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -62,6 +65,7 @@ func (c *ClusterStatusClient) Get() *ClusterStatusGetRequest {
 type ClusterStatusGetRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -81,8 +85,7 @@ func (r *ClusterStatusGetRequest) Header(name string, value interface{}) *Cluste
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *ClusterStatusGetRequest) Send() (result *ClusterStatusGetResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -90,7 +93,7 @@ func (r *ClusterStatusGetRequest) Send() (result *ClusterStatusGetResponse, err 
 // SendContext sends this request, waits for the response, and returns it.
 func (r *ClusterStatusGetRequest) SendContext(ctx context.Context) (result *ClusterStatusGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),

--- a/pkg/client/clustersmgmt/v1/credentials_client.go
+++ b/pkg/client/clustersmgmt/v1/credentials_client.go
@@ -36,15 +36,17 @@ import (
 type CredentialsClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewCredentialsClient creates a new client for the 'credentials'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewCredentialsClient(transport http.RoundTripper, path string) *CredentialsClient {
+func NewCredentialsClient(transport http.RoundTripper, path string, metric string) *CredentialsClient {
 	client := new(CredentialsClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -55,6 +57,7 @@ func (c *CredentialsClient) Get() *CredentialsGetRequest {
 	request := new(CredentialsGetRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -62,6 +65,7 @@ func (c *CredentialsClient) Get() *CredentialsGetRequest {
 type CredentialsGetRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -81,8 +85,7 @@ func (r *CredentialsGetRequest) Header(name string, value interface{}) *Credenti
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *CredentialsGetRequest) Send() (result *CredentialsGetResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -90,7 +93,7 @@ func (r *CredentialsGetRequest) Send() (result *CredentialsGetResponse, err erro
 // SendContext sends this request, waits for the response, and returns it.
 func (r *CredentialsGetRequest) SendContext(ctx context.Context) (result *CredentialsGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),

--- a/pkg/client/clustersmgmt/v1/dashboard_client.go
+++ b/pkg/client/clustersmgmt/v1/dashboard_client.go
@@ -36,15 +36,17 @@ import (
 type DashboardClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewDashboardClient creates a new client for the 'dashboard'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewDashboardClient(transport http.RoundTripper, path string) *DashboardClient {
+func NewDashboardClient(transport http.RoundTripper, path string, metric string) *DashboardClient {
 	client := new(DashboardClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -55,6 +57,7 @@ func (c *DashboardClient) Get() *DashboardGetRequest {
 	request := new(DashboardGetRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -62,6 +65,7 @@ func (c *DashboardClient) Get() *DashboardGetRequest {
 type DashboardGetRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -81,8 +85,7 @@ func (r *DashboardGetRequest) Header(name string, value interface{}) *DashboardG
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *DashboardGetRequest) Send() (result *DashboardGetResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -90,7 +93,7 @@ func (r *DashboardGetRequest) Send() (result *DashboardGetResponse, err error) {
 // SendContext sends this request, waits for the response, and returns it.
 func (r *DashboardGetRequest) SendContext(ctx context.Context) (result *DashboardGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),

--- a/pkg/client/clustersmgmt/v1/flavour_client.go
+++ b/pkg/client/clustersmgmt/v1/flavour_client.go
@@ -36,15 +36,17 @@ import (
 type FlavourClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewFlavourClient creates a new client for the 'flavour'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewFlavourClient(transport http.RoundTripper, path string) *FlavourClient {
+func NewFlavourClient(transport http.RoundTripper, path string, metric string) *FlavourClient {
 	client := new(FlavourClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -55,6 +57,7 @@ func (c *FlavourClient) Get() *FlavourGetRequest {
 	request := new(FlavourGetRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -62,6 +65,7 @@ func (c *FlavourClient) Get() *FlavourGetRequest {
 type FlavourGetRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -81,8 +85,7 @@ func (r *FlavourGetRequest) Header(name string, value interface{}) *FlavourGetRe
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *FlavourGetRequest) Send() (result *FlavourGetResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -90,7 +93,7 @@ func (r *FlavourGetRequest) Send() (result *FlavourGetResponse, err error) {
 // SendContext sends this request, waits for the response, and returns it.
 func (r *FlavourGetRequest) SendContext(ctx context.Context) (result *FlavourGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),

--- a/pkg/client/clustersmgmt/v1/group_client.go
+++ b/pkg/client/clustersmgmt/v1/group_client.go
@@ -37,15 +37,17 @@ import (
 type GroupClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewGroupClient creates a new client for the 'group'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewGroupClient(transport http.RoundTripper, path string) *GroupClient {
+func NewGroupClient(transport http.RoundTripper, path string, metric string) *GroupClient {
 	client := new(GroupClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -56,6 +58,7 @@ func (c *GroupClient) Get() *GroupGetRequest {
 	request := new(GroupGetRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -63,13 +66,18 @@ func (c *GroupClient) Get() *GroupGetRequest {
 //
 // Reference to the resource that manages the collection of users.
 func (c *GroupClient) Users() *UsersClient {
-	return NewUsersClient(c.transport, path.Join(c.path, "users"))
+	return NewUsersClient(
+		c.transport,
+		path.Join(c.path, "users"),
+		path.Join(c.metric, "users"),
+	)
 }
 
 // GroupGetRequest is the request for the 'get' method.
 type GroupGetRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -89,8 +97,7 @@ func (r *GroupGetRequest) Header(name string, value interface{}) *GroupGetReques
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *GroupGetRequest) Send() (result *GroupGetResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -98,7 +105,7 @@ func (r *GroupGetRequest) Send() (result *GroupGetResponse, err error) {
 // SendContext sends this request, waits for the response, and returns it.
 func (r *GroupGetRequest) SendContext(ctx context.Context) (result *GroupGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),

--- a/pkg/client/clustersmgmt/v1/identity_provider_client.go
+++ b/pkg/client/clustersmgmt/v1/identity_provider_client.go
@@ -36,15 +36,17 @@ import (
 type IdentityProviderClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewIdentityProviderClient creates a new client for the 'identity_provider'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewIdentityProviderClient(transport http.RoundTripper, path string) *IdentityProviderClient {
+func NewIdentityProviderClient(transport http.RoundTripper, path string, metric string) *IdentityProviderClient {
 	client := new(IdentityProviderClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -55,6 +57,7 @@ func (c *IdentityProviderClient) Get() *IdentityProviderGetRequest {
 	request := new(IdentityProviderGetRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -65,6 +68,7 @@ func (c *IdentityProviderClient) Delete() *IdentityProviderDeleteRequest {
 	request := new(IdentityProviderDeleteRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -72,6 +76,7 @@ func (c *IdentityProviderClient) Delete() *IdentityProviderDeleteRequest {
 type IdentityProviderGetRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -91,8 +96,7 @@ func (r *IdentityProviderGetRequest) Header(name string, value interface{}) *Ide
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *IdentityProviderGetRequest) Send() (result *IdentityProviderGetResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -100,7 +104,7 @@ func (r *IdentityProviderGetRequest) Send() (result *IdentityProviderGetResponse
 // SendContext sends this request, waits for the response, and returns it.
 func (r *IdentityProviderGetRequest) SendContext(ctx context.Context) (result *IdentityProviderGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),
@@ -187,6 +191,7 @@ func (r *IdentityProviderGetResponse) unmarshal(reader io.Reader) error {
 type IdentityProviderDeleteRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -206,8 +211,7 @@ func (r *IdentityProviderDeleteRequest) Header(name string, value interface{}) *
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *IdentityProviderDeleteRequest) Send() (result *IdentityProviderDeleteResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -215,7 +219,7 @@ func (r *IdentityProviderDeleteRequest) Send() (result *IdentityProviderDeleteRe
 // SendContext sends this request, waits for the response, and returns it.
 func (r *IdentityProviderDeleteRequest) SendContext(ctx context.Context) (result *IdentityProviderDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),

--- a/pkg/client/clustersmgmt/v1/identity_providers_client.go
+++ b/pkg/client/clustersmgmt/v1/identity_providers_client.go
@@ -39,15 +39,17 @@ import (
 type IdentityProvidersClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewIdentityProvidersClient creates a new client for the 'identity_providers'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewIdentityProvidersClient(transport http.RoundTripper, path string) *IdentityProvidersClient {
+func NewIdentityProvidersClient(transport http.RoundTripper, path string, metric string) *IdentityProvidersClient {
 	client := new(IdentityProvidersClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -58,6 +60,7 @@ func (c *IdentityProvidersClient) List() *IdentityProvidersListRequest {
 	request := new(IdentityProvidersListRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -68,6 +71,7 @@ func (c *IdentityProvidersClient) Add() *IdentityProvidersAddRequest {
 	request := new(IdentityProvidersAddRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -75,13 +79,18 @@ func (c *IdentityProvidersClient) Add() *IdentityProvidersAddRequest {
 //
 // Reference to the service that manages an specific identity provider.
 func (c *IdentityProvidersClient) IdentityProvider(id string) *IdentityProviderClient {
-	return NewIdentityProviderClient(c.transport, path.Join(c.path, id))
+	return NewIdentityProviderClient(
+		c.transport,
+		path.Join(c.path, id),
+		path.Join(c.metric, "-"),
+	)
 }
 
 // IdentityProvidersListRequest is the request for the 'list' method.
 type IdentityProvidersListRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -101,8 +110,7 @@ func (r *IdentityProvidersListRequest) Header(name string, value interface{}) *I
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *IdentityProvidersListRequest) Send() (result *IdentityProvidersListResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -110,7 +118,7 @@ func (r *IdentityProvidersListRequest) Send() (result *IdentityProvidersListResp
 // SendContext sends this request, waits for the response, and returns it.
 func (r *IdentityProvidersListRequest) SendContext(ctx context.Context) (result *IdentityProvidersListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),
@@ -242,6 +250,7 @@ type identityProvidersListResponseData struct {
 type IdentityProvidersAddRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 	body      *IdentityProvider
@@ -270,8 +279,7 @@ func (r *IdentityProvidersAddRequest) Body(value *IdentityProvider) *IdentityPro
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *IdentityProvidersAddRequest) Send() (result *IdentityProvidersAddResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -279,7 +287,7 @@ func (r *IdentityProvidersAddRequest) Send() (result *IdentityProvidersAddRespon
 // SendContext sends this request, waits for the response, and returns it.
 func (r *IdentityProvidersAddRequest) SendContext(ctx context.Context) (result *IdentityProvidersAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	buffer := new(bytes.Buffer)
 	err = r.marshal(buffer)
 	if err != nil {

--- a/pkg/client/clustersmgmt/v1/log_client.go
+++ b/pkg/client/clustersmgmt/v1/log_client.go
@@ -36,15 +36,17 @@ import (
 type LogClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewLogClient creates a new client for the 'log'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewLogClient(transport http.RoundTripper, path string) *LogClient {
+func NewLogClient(transport http.RoundTripper, path string, metric string) *LogClient {
 	client := new(LogClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -55,6 +57,7 @@ func (c *LogClient) Get() *LogGetRequest {
 	request := new(LogGetRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -62,6 +65,7 @@ func (c *LogClient) Get() *LogGetRequest {
 type LogGetRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -81,8 +85,7 @@ func (r *LogGetRequest) Header(name string, value interface{}) *LogGetRequest {
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *LogGetRequest) Send() (result *LogGetResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -90,7 +93,7 @@ func (r *LogGetRequest) Send() (result *LogGetResponse, err error) {
 // SendContext sends this request, waits for the response, and returns it.
 func (r *LogGetRequest) SendContext(ctx context.Context) (result *LogGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),

--- a/pkg/client/clustersmgmt/v1/root_client.go
+++ b/pkg/client/clustersmgmt/v1/root_client.go
@@ -30,15 +30,17 @@ import (
 type RootClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewRootClient creates a new client for the 'root'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewRootClient(transport http.RoundTripper, path string) *RootClient {
+func NewRootClient(transport http.RoundTripper, path string, metric string) *RootClient {
 	client := new(RootClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -46,19 +48,31 @@ func NewRootClient(transport http.RoundTripper, path string) *RootClient {
 //
 // Reference to the resource that manages the collection of clusters.
 func (c *RootClient) Clusters() *ClustersClient {
-	return NewClustersClient(c.transport, path.Join(c.path, "clusters"))
+	return NewClustersClient(
+		c.transport,
+		path.Join(c.path, "clusters"),
+		path.Join(c.metric, "clusters"),
+	)
 }
 
 // Dashboards returns the target 'dashboards' resource.
 //
 // Reference to the resource that manages the collection of dashboards.
 func (c *RootClient) Dashboards() *DashboardsClient {
-	return NewDashboardsClient(c.transport, path.Join(c.path, "dashboards"))
+	return NewDashboardsClient(
+		c.transport,
+		path.Join(c.path, "dashboards"),
+		path.Join(c.metric, "dashboards"),
+	)
 }
 
 // Flavours returns the target 'flavours' resource.
 //
 // Reference to the service that manages the collection of flavours.
 func (c *RootClient) Flavours() *FlavoursClient {
-	return NewFlavoursClient(c.transport, path.Join(c.path, "flavours"))
+	return NewFlavoursClient(
+		c.transport,
+		path.Join(c.path, "flavours"),
+		path.Join(c.metric, "flavours"),
+	)
 }

--- a/pkg/client/clustersmgmt/v1/user_client.go
+++ b/pkg/client/clustersmgmt/v1/user_client.go
@@ -36,15 +36,17 @@ import (
 type UserClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewUserClient creates a new client for the 'user'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewUserClient(transport http.RoundTripper, path string) *UserClient {
+func NewUserClient(transport http.RoundTripper, path string, metric string) *UserClient {
 	client := new(UserClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -55,6 +57,7 @@ func (c *UserClient) Get() *UserGetRequest {
 	request := new(UserGetRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -65,6 +68,7 @@ func (c *UserClient) Delete() *UserDeleteRequest {
 	request := new(UserDeleteRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -72,6 +76,7 @@ func (c *UserClient) Delete() *UserDeleteRequest {
 type UserGetRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -91,8 +96,7 @@ func (r *UserGetRequest) Header(name string, value interface{}) *UserGetRequest 
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *UserGetRequest) Send() (result *UserGetResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -100,7 +104,7 @@ func (r *UserGetRequest) Send() (result *UserGetResponse, err error) {
 // SendContext sends this request, waits for the response, and returns it.
 func (r *UserGetRequest) SendContext(ctx context.Context) (result *UserGetResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),
@@ -187,6 +191,7 @@ func (r *UserGetResponse) unmarshal(reader io.Reader) error {
 type UserDeleteRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -206,8 +211,7 @@ func (r *UserDeleteRequest) Header(name string, value interface{}) *UserDeleteRe
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *UserDeleteRequest) Send() (result *UserDeleteResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -215,7 +219,7 @@ func (r *UserDeleteRequest) Send() (result *UserDeleteResponse, err error) {
 // SendContext sends this request, waits for the response, and returns it.
 func (r *UserDeleteRequest) SendContext(ctx context.Context) (result *UserDeleteResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),

--- a/pkg/client/clustersmgmt/v1/users_client.go
+++ b/pkg/client/clustersmgmt/v1/users_client.go
@@ -39,15 +39,17 @@ import (
 type UsersClient struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 }
 
 // NewUsersClient creates a new client for the 'users'
 // resource using the given transport to sned the requests and receive the
 // responses.
-func NewUsersClient(transport http.RoundTripper, path string) *UsersClient {
+func NewUsersClient(transport http.RoundTripper, path string, metric string) *UsersClient {
 	client := new(UsersClient)
 	client.transport = transport
 	client.path = path
+	client.metric = metric
 	return client
 }
 
@@ -58,6 +60,7 @@ func (c *UsersClient) List() *UsersListRequest {
 	request := new(UsersListRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -68,6 +71,7 @@ func (c *UsersClient) Add() *UsersAddRequest {
 	request := new(UsersAddRequest)
 	request.transport = c.transport
 	request.path = c.path
+	request.metric = c.metric
 	return request
 }
 
@@ -75,13 +79,18 @@ func (c *UsersClient) Add() *UsersAddRequest {
 //
 // Reference to the service that manages an specific user.
 func (c *UsersClient) User(id string) *UserClient {
-	return NewUserClient(c.transport, path.Join(c.path, id))
+	return NewUserClient(
+		c.transport,
+		path.Join(c.path, id),
+		path.Join(c.metric, "-"),
+	)
 }
 
 // UsersListRequest is the request for the 'list' method.
 type UsersListRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 }
@@ -101,8 +110,7 @@ func (r *UsersListRequest) Header(name string, value interface{}) *UsersListRequ
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *UsersListRequest) Send() (result *UsersListResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -110,7 +118,7 @@ func (r *UsersListRequest) Send() (result *UsersListResponse, err error) {
 // SendContext sends this request, waits for the response, and returns it.
 func (r *UsersListRequest) SendContext(ctx context.Context) (result *UsersListResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	uri := &url.URL{
 		Path:     r.path,
 		RawQuery: query.Encode(),
@@ -242,6 +250,7 @@ type usersListResponseData struct {
 type UsersAddRequest struct {
 	transport http.RoundTripper
 	path      string
+	metric    string
 	query     url.Values
 	header    http.Header
 	body      *User
@@ -270,8 +279,7 @@ func (r *UsersAddRequest) Body(value *User) *UsersAddRequest {
 // Send sends this request, waits for the response, and returns it.
 //
 // This is a potentially lengthy operation, as it requires network communication.
-// Consider using a context and the SendContext method. If you don't provide a
-// context then a new background context will be created.
+// Consider using a context and the SendContext method.
 func (r *UsersAddRequest) Send() (result *UsersAddResponse, err error) {
 	return r.SendContext(context.Background())
 }
@@ -279,7 +287,7 @@ func (r *UsersAddRequest) Send() (result *UsersAddResponse, err error) {
 // SendContext sends this request, waits for the response, and returns it.
 func (r *UsersAddRequest) SendContext(ctx context.Context) (result *UsersAddResponse, err error) {
 	query := helpers.CopyQuery(r.query)
-	header := helpers.CopyHeader(r.header)
+	header := helpers.SetHeader(r.header, r.metric)
 	buffer := new(bytes.Buffer)
 	err = r.marshal(buffer)
 	if err != nil {

--- a/pkg/client/helpers/clients.go
+++ b/pkg/client/helpers/clients.go
@@ -55,15 +55,14 @@ func AddHeader(header *http.Header, name string, value interface{}) {
 	header.Add(name, fmt.Sprintf("%v", value))
 }
 
-// CopyHeader creates a copy of the given set of headers.
-func CopyHeader(header http.Header) http.Header {
-	if header == nil {
-		return nil
-	}
+// SetHeader creates a copy of the given set of headers, and adds the header
+// containing the given metrics path.
+func SetHeader(header http.Header, metric string) http.Header {
 	result := make(http.Header)
 	for name, values := range header {
 		result[name] = CopyValues(values)
 	}
+	result.Set(metricHeader, metric)
 	return result
 }
 
@@ -76,3 +75,6 @@ func CopyValues(values []string) []string {
 	copy(result, values)
 	return result
 }
+
+// Name of the header used to contain the metrics path:
+const metricHeader = "X-Metric"

--- a/pkg/client/metrics.go
+++ b/pkg/client/metrics.go
@@ -1,0 +1,140 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains the implementations of the Prometheus metrics.
+
+package client
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// registerMetrics registers the metrics with the Prometheus library.
+func (c *Connection) registerMetrics(subsystem string) error {
+	var err error
+
+	// Register the token request count metric:
+	c.tokenCountMetric = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "token_request_count",
+			Help:      "Number of token requests sent.",
+		},
+		tokenMetricsLabels,
+	)
+	err = prometheus.Register(c.tokenCountMetric)
+	if err != nil {
+		registered, ok := err.(prometheus.AlreadyRegisteredError)
+		if ok {
+			c.tokenCountMetric = registered.ExistingCollector.(*prometheus.CounterVec)
+		} else {
+			return err
+		}
+	}
+
+	// Description of the token request duration metric:
+	c.tokenDurationMetric = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: subsystem,
+			Name:      "token_request_duration",
+			Help:      "Token request duration in seconds.",
+			Buckets: []float64{
+				0.1,
+				1.0,
+				10.0,
+				30.0,
+			},
+		},
+		tokenMetricsLabels,
+	)
+	err = prometheus.Register(c.tokenDurationMetric)
+	if err != nil {
+		registered, ok := err.(prometheus.AlreadyRegisteredError)
+		if ok {
+			c.tokenDurationMetric = registered.ExistingCollector.(*prometheus.HistogramVec)
+		} else {
+			return err
+		}
+	}
+
+	// Register the call count metric:
+	c.callCountMetric = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "request_count",
+			Help:      "Number of requests sent.",
+		},
+		callMetricsLabels,
+	)
+	err = prometheus.Register(c.callCountMetric)
+	if err != nil {
+		registered, ok := err.(prometheus.AlreadyRegisteredError)
+		if ok {
+			c.callCountMetric = registered.ExistingCollector.(*prometheus.CounterVec)
+		} else {
+			return err
+		}
+	}
+
+	// Description of the call duration metric:
+	c.callDurationMetric = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: subsystem,
+			Name:      "request_duration",
+			Help:      "Request duration in seconds.",
+			Buckets: []float64{
+				0.1,
+				1.0,
+				10.0,
+				30.0,
+			},
+		},
+		callMetricsLabels,
+	)
+	err = prometheus.Register(c.callDurationMetric)
+	if err != nil {
+		registered, ok := err.(prometheus.AlreadyRegisteredError)
+		if ok {
+			c.callDurationMetric = registered.ExistingCollector.(*prometheus.HistogramVec)
+		} else {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Names of the labels added to metrics:
+const (
+	metricsCodeLabel   = "code"
+	metricsMethodLabel = "method"
+	metricsPathLabel   = "path"
+)
+
+// Array of labels added to token metrics:
+var tokenMetricsLabels = []string{
+	metricsCodeLabel,
+}
+
+// Array of labels added to call metrics:
+var callMetricsLabels = []string{
+	metricsCodeLabel,
+	metricsMethodLabel,
+	metricsPathLabel,
+}
+
+// Name of the header that contains the metrics path:
+const metricHeader = "X-Metric"


### PR DESCRIPTION
This patch changes the SDK so that it optionally reports the following
metrics using the Prometheus client library:

- `api_outbound_request_count` - Number of API requests sent.
- `api_outbound_request_duration_sum` - Total time to send API requests, in seconds.
- `api_outbound_request_duration_count` - Total number of API requests measured.
- `api_outbound_request_duration_bucket` - Number of API requests organized in buckets.
- `api_outbound_token_request_count` - Number of token requests sent.
- `api_outbound_token_request_duration_sum` - Total time to send token requests, in seconds.
- `api_outbound_token_request_duration_count` - Total number of token requests measured.
- `api_outbound_token_request_duration_bucket` - Number of token requests organized in buckets.

The duration buckets metrics contain an `le` label that indicates the
upper bound. For example if the `le` label is `1` then the value will be
the number of requests that were processed in less than one second.

The API request metrics have the following labels:

- `method` - Name of the HTTP method, for example GET or POST.
- `path` - Request path, for example /api/clusters_mgmt/v1/clusters.
- `code` - HTTP response code, for example 200 or 500.

To calculate the average request duration during the last 10 minutes,
for example, use a Prometheus expression like this:

```
rate(api_outbound_request_duration_sum[10m]) / rate(api_outbound_request_duration_count[10m])
```

In order to reduce the cardinality of the metrics the path label is
modified to remove the identifiers of the objects. For example, if the
original path is `.../clusters/123` then it will be replaced by
`.../clusters/-`, and the values will be accumulated. The line returned
by the metrics server will be like this:

```
api_outbound_request_count{code="200",method="GET",path="/api/clusters_mgmt/v1/clusters/-"} 56
```

The meaning of that is that there were a total of 56 requests to get
specific clusters, independently of the specific identifier of the
cluster.

The token request metrics will contain the following labels:

- `code` - HTTP response code, for example 200 or 500.

The value of the `code` label will be zero when sending the request
failed without a response code, for example if it wasn't possible to
open the connection, or if there was a timeout waiting for the response.

Note that setting this attribute is not enougth to have metrics
published, you also need to create and start a metrics server, as
described in the documentation of the Prometheus library.