### PR TITLE
Fix panic in case there's an error during send

### DIFF
--- a/pkg/client/send.go
+++ b/pkg/client/send.go
@@ -56,6 +56,9 @@ func (c *Connection) RoundTrip(request *http.Request) (response *http.Response, 
 	// it in the log:
 	before := time.Now()
 	response, err = c.send(ctx, request)
+	if err != nil {
+		return
+	}
 	after := time.Now()
 	elapsed := after.Sub(before)
 


### PR DESCRIPTION
If send() fails, the response will be nil, and metrics collection will fail on nil referencing attempt.