### PR TITLE
Don't panic if there is no response

### DIFF
--- a/pkg/client/send.go
+++ b/pkg/client/send.go
@@ -61,10 +61,14 @@ func (c *Connection) RoundTrip(request *http.Request) (response *http.Response, 
 
 	// Update the metrics:
 	if c.callCountMetric != nil || c.callDurationMetric != nil {
+		code := 0
+		if response != nil {
+			code = response.StatusCode
+		}
 		labels := map[string]string{
 			metricsMethodLabel: request.Method,
 			metricsPathLabel:   metric,
-			metricsCodeLabel:   strconv.Itoa(response.StatusCode),
+			metricsCodeLabel:   strconv.Itoa(code),
 		}
 		if c.callCountMetric != nil {
 			c.callCountMetric.With(labels).Inc()


### PR DESCRIPTION
Currently the SDK panics when no response is received, for example when
there is a timeout. The reason for that is that the code still tries to
get the response code, in order to update metrics, and that causes a
segmentation violation. This patch fixes that issue.