### PR TITLE
Release 0.1.14

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,12 @@
 This document describes the relevant changes between releases of the UHC API
 SDK.
 
+== 0.1.14 Jun 4 2019
+
+- Redact sensitive fields in debug logs.
+
+- Don't crash when there is no response.
+
 == 0.1.13 May 22 2019
 
 - Added support for building objects with attributes that are lists of structs.

--- a/pkg/client/version.go
+++ b/pkg/client/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package client
 
-const Version = "0.1.13"
+const Version = "0.1.14"


### PR DESCRIPTION
The more relevant changes in this version are the following:

- Redact sensitive fields in debug logs.

- Don't crash when there is no response.