### PR TITLE
Add missing subscription and account attributes

### DIFF
--- a/examples/list_cluster_creators.go
+++ b/examples/list_cluster_creators.go
@@ -1,0 +1,162 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This example shows how to get the e-mail addresses of the creators of managed clusters.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/openshift-online/uhc-sdk-go/pkg/client"
+	"github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1"
+)
+
+func main() {
+	// Create a context:
+	ctx := context.Background()
+
+	// Create a logger:
+	logger, err := client.NewGoLoggerBuilder().
+		Debug(false).
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build logger: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Create the connection, and remember to close it:
+	token := os.Getenv("UHC_TOKEN")
+	connection, err := client.NewConnectionBuilder().
+		Logger(logger).
+		Tokens(token).
+		BuildContext(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build client: %v\n", err)
+		os.Exit(1)
+	}
+	defer connection.Close()
+
+	// Get the client for the collections that we will be using:
+	clustersCollection := connection.ClustersMgmt().V1().Clusters()
+	subscriptionsCollection := connection.AccountsMgmt().V1().Subscriptions()
+	accountsCollection := connection.AccountsMgmt().V1().Accounts()
+
+	// Create a tab writer that will be used to print the results in columns and print the
+	// header line:
+	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(writer, "ID\tNAME\tUSER\tMAIL\n")
+
+	// Retrieve the list of clusters using pages of ten items, till we get a page that has less
+	// items than requests, as that marks the end of the collection:
+	size := 10
+	page := 1
+	for {
+		// Retrieve the page:
+		listClustersResponse, err := clustersCollection.List().
+			Search("managed = 't'").
+			Size(size).
+			Page(page).
+			SendContext(ctx)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Can't retrieve clusters page %d: %s\n", page, err)
+			os.Exit(1)
+		}
+
+		// Process the page:
+		listClustersResponse.Items().Each(func(cluster *v1.Cluster) bool {
+			// Get the cluster data:
+			clusterID := cluster.ID()
+			clusterName := cluster.Name()
+
+			// If the cluster doesn't have a link to the subscription then ignore it,
+			// otherwise get the identifier of the subscription from the link:
+			subscriptionLink := cluster.Subscription()
+			if subscriptionLink == nil {
+				return true
+			}
+			subscriptionID := subscriptionLink.ID()
+
+			// Retrieve the details of the subscription, so that we can follow the link
+			// to the account that created it:
+			subscriptionResource := subscriptionsCollection.Subscription(subscriptionID)
+			subscriptionGetResponse, err := subscriptionResource.Get().Send()
+			if err != nil {
+				fmt.Fprintf(
+					os.Stderr,
+					"Can't retrieve details of subscription '%s' for cluster '%s': %v\n",
+					subscriptionID, clusterID, err,
+				)
+				os.Exit(1)
+			}
+			subscription := subscriptionGetResponse.Body()
+
+			// If the subscription doesn't have a link to the account that created it
+			// then ignore it, otherwise get the identifier of the account from the
+			// link:
+			creatorLink := subscription.Creator()
+			if creatorLink == nil {
+				return true
+			}
+			creatorID := creatorLink.ID()
+
+			// Retrieve the details of the account:
+			accountResource := accountsCollection.Account(creatorID)
+			accountGetResponse, err := accountResource.Get().Send()
+			if err != nil {
+				fmt.Fprintf(
+					os.Stderr,
+					"Can't retrieve details of creator account '%s' for "+
+						"subscription '%s' and cluster '%s': %v\n",
+					creatorID, subscriptionID, clusterID,
+				)
+				os.Exit(1)
+			}
+			account := accountGetResponse.Body()
+
+			// Get the account data:
+			creatorFirst := account.FirstName()
+			creatorLast := account.LastName()
+			creatorMail := account.Email()
+
+			// Print the results:
+			fmt.Fprintf(
+				writer,
+				"%s\t%s\t%s %s\t%s\n",
+				clusterID,
+				clusterName,
+				creatorFirst,
+				creatorLast,
+				creatorMail,
+			)
+
+			return true
+		})
+
+		// Break the loop if the size of the page is less than requested, otherwise go to
+		// the next page:
+		if listClustersResponse.Size() < size {
+			break
+		}
+		page++
+	}
+
+	// Flush the tab writer, otherwise the results may not be displayed:
+	writer.Flush()
+}

--- a/pkg/client/accountsmgmt/v1/account_builder.go
+++ b/pkg/client/accountsmgmt/v1/account_builder.go
@@ -29,6 +29,8 @@ type AccountBuilder struct {
 	name           *string
 	username       *string
 	email          *string
+	firstName      *string
+	lastName       *string
 	banned         *bool
 	banDescription *string
 	organization   *OrganizationBuilder
@@ -84,6 +86,24 @@ func (b *AccountBuilder) Email(value string) *AccountBuilder {
 	return b
 }
 
+// FirstName sets the value of the 'first_name' attribute
+// to the given value.
+//
+//
+func (b *AccountBuilder) FirstName(value string) *AccountBuilder {
+	b.firstName = &value
+	return b
+}
+
+// LastName sets the value of the 'last_name' attribute
+// to the given value.
+//
+//
+func (b *AccountBuilder) LastName(value string) *AccountBuilder {
+	b.lastName = &value
+	return b
+}
+
 // Banned sets the value of the 'banned' attribute
 // to the given value.
 //
@@ -125,6 +145,12 @@ func (b *AccountBuilder) Build() (object *Account, err error) {
 	}
 	if b.email != nil {
 		object.email = b.email
+	}
+	if b.firstName != nil {
+		object.firstName = b.firstName
+	}
+	if b.lastName != nil {
+		object.lastName = b.lastName
 	}
 	if b.banned != nil {
 		object.banned = b.banned

--- a/pkg/client/accountsmgmt/v1/account_reader.go
+++ b/pkg/client/accountsmgmt/v1/account_reader.go
@@ -34,6 +34,8 @@ type accountData struct {
 	Name           *string           "json:\"name,omitempty\""
 	Username       *string           "json:\"username,omitempty\""
 	Email          *string           "json:\"email,omitempty\""
+	FirstName      *string           "json:\"first_name,omitempty\""
+	LastName       *string           "json:\"last_name,omitempty\""
 	Banned         *bool             "json:\"banned,omitempty\""
 	BanDescription *string           "json:\"ban_description,omitempty\""
 	Organization   *organizationData "json:\"organization,omitempty\""
@@ -71,6 +73,8 @@ func (o *Account) wrap() (data *accountData, err error) {
 	data.Name = o.name
 	data.Username = o.username
 	data.Email = o.email
+	data.FirstName = o.firstName
+	data.LastName = o.lastName
 	data.Banned = o.banned
 	data.BanDescription = o.banDescription
 	data.Organization, err = o.organization.wrap()
@@ -124,6 +128,8 @@ func (d *accountData) unwrap() (object *Account, err error) {
 	object.name = d.Name
 	object.username = d.Username
 	object.email = d.Email
+	object.firstName = d.FirstName
+	object.lastName = d.LastName
 	object.banned = d.Banned
 	object.banDescription = d.BanDescription
 	object.organization, err = d.Organization.unwrap()

--- a/pkg/client/accountsmgmt/v1/account_type.go
+++ b/pkg/client/accountsmgmt/v1/account_type.go
@@ -41,6 +41,8 @@ type Account struct {
 	name           *string
 	username       *string
 	email          *string
+	firstName      *string
+	lastName       *string
 	banned         *bool
 	banDescription *string
 	organization   *Organization
@@ -104,6 +106,8 @@ func (o *Account) Empty() bool {
 		o.name == nil &&
 		o.username == nil &&
 		o.email == nil &&
+		o.firstName == nil &&
+		o.lastName == nil &&
 		o.banned == nil &&
 		o.banDescription == nil &&
 		o.organization == nil &&
@@ -175,6 +179,52 @@ func (o *Account) GetEmail() (value string, ok bool) {
 	ok = o != nil && o.email != nil
 	if ok {
 		value = *o.email
+	}
+	return
+}
+
+// FirstName returns the value of the 'first_name' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+//
+func (o *Account) FirstName() string {
+	if o != nil && o.firstName != nil {
+		return *o.firstName
+	}
+	return ""
+}
+
+// GetFirstName returns the value of the 'first_name' attribute and
+// a flag indicating if the attribute has a value.
+//
+//
+func (o *Account) GetFirstName() (value string, ok bool) {
+	ok = o != nil && o.firstName != nil
+	if ok {
+		value = *o.firstName
+	}
+	return
+}
+
+// LastName returns the value of the 'last_name' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+//
+func (o *Account) LastName() string {
+	if o != nil && o.lastName != nil {
+		return *o.lastName
+	}
+	return ""
+}
+
+// GetLastName returns the value of the 'last_name' attribute and
+// a flag indicating if the attribute has a value.
+//
+//
+func (o *Account) GetLastName() (value string, ok bool) {
+	ok = o != nil && o.lastName != nil
+	if ok {
+		value = *o.lastName
 	}
 	return
 }

--- a/pkg/client/accountsmgmt/v1/subscription_builder.go
+++ b/pkg/client/accountsmgmt/v1/subscription_builder.go
@@ -36,6 +36,7 @@ type SubscriptionBuilder struct {
 	externalClusterID  *string
 	organizationID     *string
 	lastTelemetryDate  *time.Time
+	creator            *AccountBuilder
 }
 
 // NewSubscription creates a new builder of 'subscription' objects.
@@ -115,6 +116,15 @@ func (b *SubscriptionBuilder) LastTelemetryDate(value time.Time) *SubscriptionBu
 	return b
 }
 
+// Creator sets the value of the 'creator' attribute
+// to the given value.
+//
+//
+func (b *SubscriptionBuilder) Creator(value *AccountBuilder) *SubscriptionBuilder {
+	b.creator = value
+	return b
+}
+
 // Build creates a 'subscription' object using the configuration stored in the builder.
 func (b *SubscriptionBuilder) Build() (object *Subscription, err error) {
 	object = new(Subscription)
@@ -144,6 +154,12 @@ func (b *SubscriptionBuilder) Build() (object *Subscription, err error) {
 	}
 	if b.lastTelemetryDate != nil {
 		object.lastTelemetryDate = b.lastTelemetryDate
+	}
+	if b.creator != nil {
+		object.creator, err = b.creator.Build()
+		if err != nil {
+			return
+		}
 	}
 	return
 }

--- a/pkg/client/accountsmgmt/v1/subscription_reader.go
+++ b/pkg/client/accountsmgmt/v1/subscription_reader.go
@@ -38,6 +38,7 @@ type subscriptionData struct {
 	ExternalClusterID  *string                 "json:\"external_cluster_id,omitempty\""
 	OrganizationID     *string                 "json:\"organization_id,omitempty\""
 	LastTelemetryDate  *time.Time              "json:\"last_telemetry_date,omitempty\""
+	Creator            *accountData            "json:\"creator,omitempty\""
 }
 
 // MarshalSubscription writes a value of the 'subscription' to the given target,
@@ -81,6 +82,10 @@ func (o *Subscription) wrap() (data *subscriptionData, err error) {
 	data.ExternalClusterID = o.externalClusterID
 	data.OrganizationID = o.organizationID
 	data.LastTelemetryDate = o.lastTelemetryDate
+	data.Creator, err = o.creator.wrap()
+	if err != nil {
+		return
+	}
 	return
 }
 
@@ -137,5 +142,9 @@ func (d *subscriptionData) unwrap() (object *Subscription, err error) {
 	object.externalClusterID = d.ExternalClusterID
 	object.organizationID = d.OrganizationID
 	object.lastTelemetryDate = d.LastTelemetryDate
+	object.creator, err = d.Creator.unwrap()
+	if err != nil {
+		return
+	}
 	return
 }

--- a/pkg/client/accountsmgmt/v1/subscription_type.go
+++ b/pkg/client/accountsmgmt/v1/subscription_type.go
@@ -48,6 +48,7 @@ type Subscription struct {
 	externalClusterID  *string
 	organizationID     *string
 	lastTelemetryDate  *time.Time
+	creator            *Account
 }
 
 // Kind returns the name of the type of the object.
@@ -111,6 +112,7 @@ func (o *Subscription) Empty() bool {
 		o.externalClusterID == nil &&
 		o.organizationID == nil &&
 		o.lastTelemetryDate == nil &&
+		o.creator == nil &&
 		true)
 }
 
@@ -248,6 +250,29 @@ func (o *Subscription) GetLastTelemetryDate() (value time.Time, ok bool) {
 	ok = o != nil && o.lastTelemetryDate != nil
 	if ok {
 		value = *o.lastTelemetryDate
+	}
+	return
+}
+
+// Creator returns the value of the 'creator' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Link to the account that created the subscription.
+func (o *Subscription) Creator() *Account {
+	if o == nil {
+		return nil
+	}
+	return o.creator
+}
+
+// GetCreator returns the value of the 'creator' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Link to the account that created the subscription.
+func (o *Subscription) GetCreator() (value *Account, ok bool) {
+	ok = o != nil && o.creator != nil
+	if ok {
+		value = o.creator
 	}
 	return
 }


### PR DESCRIPTION
This patch adds support for some missing attributes in the subscription
and account types, and an example that shows how to use them.