### PR TITLE
Add getters with presence flag to responses

### DIFF
--- a/pkg/client/accountsmgmt/v1/access_token_client.go
+++ b/pkg/client/accountsmgmt/v1/access_token_client.go
@@ -156,7 +156,22 @@ func (r *AccessTokenPostResponse) Error() *errors.Error {
 //
 //
 func (r *AccessTokenPostResponse) Body() *AccessToken {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *AccessTokenPostResponse) GetBody() (value *AccessToken, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/account_client.go
+++ b/pkg/client/accountsmgmt/v1/account_client.go
@@ -169,7 +169,22 @@ func (r *AccountGetResponse) Error() *errors.Error {
 //
 //
 func (r *AccountGetResponse) Body() *Account {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *AccountGetResponse) GetBody() (value *Account, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the
@@ -312,7 +327,22 @@ func (r *AccountUpdateResponse) Error() *errors.Error {
 //
 //
 func (r *AccountUpdateResponse) Body() *Account {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *AccountUpdateResponse) GetBody() (value *Account, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/accounts_client.go
+++ b/pkg/client/accountsmgmt/v1/accounts_client.go
@@ -227,10 +227,24 @@ func (r *AccountsListResponse) Error() *errors.Error {
 //
 // Default value is `1`.
 func (r *AccountsListResponse) Page() int {
-	if r.page != nil {
+	if r != nil && r.page != nil {
 		return *r.page
 	}
 	return 0
+}
+
+// GetPage returns the value of the 'page' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Index of the requested page, where one corresponds to the first page.
+//
+// Default value is `1`.
+func (r *AccountsListResponse) GetPage() (value int, ok bool) {
+	ok = r != nil && r.page != nil
+	if ok {
+		value = *r.page
+	}
+	return
 }
 
 // Size returns the value of the 'size' parameter.
@@ -239,10 +253,24 @@ func (r *AccountsListResponse) Page() int {
 //
 // Default value is `100`.
 func (r *AccountsListResponse) Size() int {
-	if r.size != nil {
+	if r != nil && r.size != nil {
 		return *r.size
 	}
 	return 0
+}
+
+// GetSize returns the value of the 'size' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Maximum number of items that will be contained in the returned page.
+//
+// Default value is `100`.
+func (r *AccountsListResponse) GetSize() (value int, ok bool) {
+	ok = r != nil && r.size != nil
+	if ok {
+		value = *r.size
+	}
+	return
 }
 
 // Total returns the value of the 'total' parameter.
@@ -250,17 +278,45 @@ func (r *AccountsListResponse) Size() int {
 // Total number of items of the collection that match the search criteria,
 // regardless of the size of the page.
 func (r *AccountsListResponse) Total() int {
-	if r.total != nil {
+	if r != nil && r.total != nil {
 		return *r.total
 	}
 	return 0
+}
+
+// GetTotal returns the value of the 'total' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Total number of items of the collection that match the search criteria,
+// regardless of the size of the page.
+func (r *AccountsListResponse) GetTotal() (value int, ok bool) {
+	ok = r != nil && r.total != nil
+	if ok {
+		value = *r.total
+	}
+	return
 }
 
 // Items returns the value of the 'items' parameter.
 //
 // Retrieved list of accounts.
 func (r *AccountsListResponse) Items() *AccountList {
+	if r == nil {
+		return nil
+	}
 	return r.items
+}
+
+// GetItems returns the value of the 'items' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Retrieved list of accounts.
+func (r *AccountsListResponse) GetItems() (value *AccountList, ok bool) {
+	ok = r != nil && r.items != nil
+	if ok {
+		value = r.items
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the
@@ -415,7 +471,22 @@ func (r *AccountsAddResponse) Error() *errors.Error {
 //
 // Account data.
 func (r *AccountsAddResponse) Body() *Account {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Account data.
+func (r *AccountsAddResponse) GetBody() (value *Account, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/cluster_authorizations_client.go
+++ b/pkg/client/accountsmgmt/v1/cluster_authorizations_client.go
@@ -186,7 +186,22 @@ func (r *ClusterAuthorizationsPostResponse) Error() *errors.Error {
 //
 //
 func (r *ClusterAuthorizationsPostResponse) Response() *ClusterAuthorizationResponse {
+	if r == nil {
+		return nil
+	}
 	return r.response
+}
+
+// GetResponse returns the value of the 'response' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *ClusterAuthorizationsPostResponse) GetResponse() (value *ClusterAuthorizationResponse, ok bool) {
+	ok = r != nil && r.response != nil
+	if ok {
+		value = r.response
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/cluster_registrations_client.go
+++ b/pkg/client/accountsmgmt/v1/cluster_registrations_client.go
@@ -187,7 +187,22 @@ func (r *ClusterRegistrationsPostResponse) Error() *errors.Error {
 //
 //
 func (r *ClusterRegistrationsPostResponse) Response() *ClusterRegistrationResponse {
+	if r == nil {
+		return nil
+	}
 	return r.response
+}
+
+// GetResponse returns the value of the 'response' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *ClusterRegistrationsPostResponse) GetResponse() (value *ClusterRegistrationResponse, ok bool) {
+	ok = r != nil && r.response != nil
+	if ok {
+		value = r.response
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/current_account_client.go
+++ b/pkg/client/accountsmgmt/v1/current_account_client.go
@@ -156,7 +156,22 @@ func (r *CurrentAccountGetResponse) Error() *errors.Error {
 //
 //
 func (r *CurrentAccountGetResponse) Body() *Account {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *CurrentAccountGetResponse) GetBody() (value *Account, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/organization_client.go
+++ b/pkg/client/accountsmgmt/v1/organization_client.go
@@ -182,7 +182,22 @@ func (r *OrganizationGetResponse) Error() *errors.Error {
 //
 //
 func (r *OrganizationGetResponse) Body() *Organization {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *OrganizationGetResponse) GetBody() (value *Organization, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the
@@ -325,7 +340,22 @@ func (r *OrganizationUpdateResponse) Error() *errors.Error {
 //
 //
 func (r *OrganizationUpdateResponse) Body() *Organization {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *OrganizationUpdateResponse) GetBody() (value *Organization, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/organizations_client.go
+++ b/pkg/client/accountsmgmt/v1/organizations_client.go
@@ -227,10 +227,24 @@ func (r *OrganizationsListResponse) Error() *errors.Error {
 //
 // Default value is `1`.
 func (r *OrganizationsListResponse) Page() int {
-	if r.page != nil {
+	if r != nil && r.page != nil {
 		return *r.page
 	}
 	return 0
+}
+
+// GetPage returns the value of the 'page' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Index of the requested page, where one corresponds to the first page.
+//
+// Default value is `1`.
+func (r *OrganizationsListResponse) GetPage() (value int, ok bool) {
+	ok = r != nil && r.page != nil
+	if ok {
+		value = *r.page
+	}
+	return
 }
 
 // Size returns the value of the 'size' parameter.
@@ -239,10 +253,24 @@ func (r *OrganizationsListResponse) Page() int {
 //
 // Default value is `100`.
 func (r *OrganizationsListResponse) Size() int {
-	if r.size != nil {
+	if r != nil && r.size != nil {
 		return *r.size
 	}
 	return 0
+}
+
+// GetSize returns the value of the 'size' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Maximum number of items that will be contained in the returned page.
+//
+// Default value is `100`.
+func (r *OrganizationsListResponse) GetSize() (value int, ok bool) {
+	ok = r != nil && r.size != nil
+	if ok {
+		value = *r.size
+	}
+	return
 }
 
 // Total returns the value of the 'total' parameter.
@@ -250,17 +278,45 @@ func (r *OrganizationsListResponse) Size() int {
 // Total number of items of the collection that match the search criteria,
 // regardless of the size of the page.
 func (r *OrganizationsListResponse) Total() int {
-	if r.total != nil {
+	if r != nil && r.total != nil {
 		return *r.total
 	}
 	return 0
+}
+
+// GetTotal returns the value of the 'total' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Total number of items of the collection that match the search criteria,
+// regardless of the size of the page.
+func (r *OrganizationsListResponse) GetTotal() (value int, ok bool) {
+	ok = r != nil && r.total != nil
+	if ok {
+		value = *r.total
+	}
+	return
 }
 
 // Items returns the value of the 'items' parameter.
 //
 // Retrieved list of organizations.
 func (r *OrganizationsListResponse) Items() *OrganizationList {
+	if r == nil {
+		return nil
+	}
 	return r.items
+}
+
+// GetItems returns the value of the 'items' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Retrieved list of organizations.
+func (r *OrganizationsListResponse) GetItems() (value *OrganizationList, ok bool) {
+	ok = r != nil && r.items != nil
+	if ok {
+		value = r.items
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the
@@ -415,7 +471,22 @@ func (r *OrganizationsAddResponse) Error() *errors.Error {
 //
 // Organization data.
 func (r *OrganizationsAddResponse) Body() *Organization {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Organization data.
+func (r *OrganizationsAddResponse) GetBody() (value *Organization, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/permission_client.go
+++ b/pkg/client/accountsmgmt/v1/permission_client.go
@@ -167,7 +167,22 @@ func (r *PermissionGetResponse) Error() *errors.Error {
 //
 //
 func (r *PermissionGetResponse) Body() *Permission {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *PermissionGetResponse) GetBody() (value *Permission, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/permissions_client.go
+++ b/pkg/client/accountsmgmt/v1/permissions_client.go
@@ -227,10 +227,24 @@ func (r *PermissionsListResponse) Error() *errors.Error {
 //
 // Default value is `1`.
 func (r *PermissionsListResponse) Page() int {
-	if r.page != nil {
+	if r != nil && r.page != nil {
 		return *r.page
 	}
 	return 0
+}
+
+// GetPage returns the value of the 'page' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Index of the requested page, where one corresponds to the first page.
+//
+// Default value is `1`.
+func (r *PermissionsListResponse) GetPage() (value int, ok bool) {
+	ok = r != nil && r.page != nil
+	if ok {
+		value = *r.page
+	}
+	return
 }
 
 // Size returns the value of the 'size' parameter.
@@ -239,10 +253,24 @@ func (r *PermissionsListResponse) Page() int {
 //
 // Default value is `100`.
 func (r *PermissionsListResponse) Size() int {
-	if r.size != nil {
+	if r != nil && r.size != nil {
 		return *r.size
 	}
 	return 0
+}
+
+// GetSize returns the value of the 'size' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Maximum number of items that will be contained in the returned page.
+//
+// Default value is `100`.
+func (r *PermissionsListResponse) GetSize() (value int, ok bool) {
+	ok = r != nil && r.size != nil
+	if ok {
+		value = *r.size
+	}
+	return
 }
 
 // Total returns the value of the 'total' parameter.
@@ -250,17 +278,45 @@ func (r *PermissionsListResponse) Size() int {
 // Total number of items of the collection that match the search criteria,
 // regardless of the size of the page.
 func (r *PermissionsListResponse) Total() int {
-	if r.total != nil {
+	if r != nil && r.total != nil {
 		return *r.total
 	}
 	return 0
+}
+
+// GetTotal returns the value of the 'total' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Total number of items of the collection that match the search criteria,
+// regardless of the size of the page.
+func (r *PermissionsListResponse) GetTotal() (value int, ok bool) {
+	ok = r != nil && r.total != nil
+	if ok {
+		value = *r.total
+	}
+	return
 }
 
 // Items returns the value of the 'items' parameter.
 //
 // Retrieved list of permissions.
 func (r *PermissionsListResponse) Items() *PermissionList {
+	if r == nil {
+		return nil
+	}
 	return r.items
+}
+
+// GetItems returns the value of the 'items' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Retrieved list of permissions.
+func (r *PermissionsListResponse) GetItems() (value *PermissionList, ok bool) {
+	ok = r != nil && r.items != nil
+	if ok {
+		value = r.items
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the
@@ -415,7 +471,22 @@ func (r *PermissionsAddResponse) Error() *errors.Error {
 //
 // Permission data.
 func (r *PermissionsAddResponse) Body() *Permission {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Permission data.
+func (r *PermissionsAddResponse) GetBody() (value *Permission, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/registries_client.go
+++ b/pkg/client/accountsmgmt/v1/registries_client.go
@@ -214,10 +214,24 @@ func (r *RegistriesListResponse) Error() *errors.Error {
 //
 // Default value is `1`.
 func (r *RegistriesListResponse) Page() int {
-	if r.page != nil {
+	if r != nil && r.page != nil {
 		return *r.page
 	}
 	return 0
+}
+
+// GetPage returns the value of the 'page' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Index of the requested page, where one corresponds to the first page.
+//
+// Default value is `1`.
+func (r *RegistriesListResponse) GetPage() (value int, ok bool) {
+	ok = r != nil && r.page != nil
+	if ok {
+		value = *r.page
+	}
+	return
 }
 
 // Size returns the value of the 'size' parameter.
@@ -226,10 +240,24 @@ func (r *RegistriesListResponse) Page() int {
 //
 // Default value is `100`.
 func (r *RegistriesListResponse) Size() int {
-	if r.size != nil {
+	if r != nil && r.size != nil {
 		return *r.size
 	}
 	return 0
+}
+
+// GetSize returns the value of the 'size' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Maximum number of items that will be contained in the returned page.
+//
+// Default value is `100`.
+func (r *RegistriesListResponse) GetSize() (value int, ok bool) {
+	ok = r != nil && r.size != nil
+	if ok {
+		value = *r.size
+	}
+	return
 }
 
 // Total returns the value of the 'total' parameter.
@@ -237,17 +265,45 @@ func (r *RegistriesListResponse) Size() int {
 // Total number of items of the collection that match the search criteria,
 // regardless of the size of the page.
 func (r *RegistriesListResponse) Total() int {
-	if r.total != nil {
+	if r != nil && r.total != nil {
 		return *r.total
 	}
 	return 0
+}
+
+// GetTotal returns the value of the 'total' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Total number of items of the collection that match the search criteria,
+// regardless of the size of the page.
+func (r *RegistriesListResponse) GetTotal() (value int, ok bool) {
+	ok = r != nil && r.total != nil
+	if ok {
+		value = *r.total
+	}
+	return
 }
 
 // Items returns the value of the 'items' parameter.
 //
 // Retrieved list of registries.
 func (r *RegistriesListResponse) Items() *RegistryList {
+	if r == nil {
+		return nil
+	}
 	return r.items
+}
+
+// GetItems returns the value of the 'items' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Retrieved list of registries.
+func (r *RegistriesListResponse) GetItems() (value *RegistryList, ok bool) {
+	ok = r != nil && r.items != nil
+	if ok {
+		value = r.items
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/registry_client.go
+++ b/pkg/client/accountsmgmt/v1/registry_client.go
@@ -156,7 +156,22 @@ func (r *RegistryGetResponse) Error() *errors.Error {
 //
 //
 func (r *RegistryGetResponse) Body() *Registry {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *RegistryGetResponse) GetBody() (value *Registry, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/registry_credential_client.go
+++ b/pkg/client/accountsmgmt/v1/registry_credential_client.go
@@ -156,7 +156,22 @@ func (r *RegistryCredentialGetResponse) Error() *errors.Error {
 //
 //
 func (r *RegistryCredentialGetResponse) Body() *RegistryCredential {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *RegistryCredentialGetResponse) GetBody() (value *RegistryCredential, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/registry_credentials_client.go
+++ b/pkg/client/accountsmgmt/v1/registry_credentials_client.go
@@ -227,10 +227,24 @@ func (r *RegistryCredentialsListResponse) Error() *errors.Error {
 //
 // Default value is `1`.
 func (r *RegistryCredentialsListResponse) Page() int {
-	if r.page != nil {
+	if r != nil && r.page != nil {
 		return *r.page
 	}
 	return 0
+}
+
+// GetPage returns the value of the 'page' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Index of the requested page, where one corresponds to the first page.
+//
+// Default value is `1`.
+func (r *RegistryCredentialsListResponse) GetPage() (value int, ok bool) {
+	ok = r != nil && r.page != nil
+	if ok {
+		value = *r.page
+	}
+	return
 }
 
 // Size returns the value of the 'size' parameter.
@@ -239,10 +253,24 @@ func (r *RegistryCredentialsListResponse) Page() int {
 //
 // Default value is `100`.
 func (r *RegistryCredentialsListResponse) Size() int {
-	if r.size != nil {
+	if r != nil && r.size != nil {
 		return *r.size
 	}
 	return 0
+}
+
+// GetSize returns the value of the 'size' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Maximum number of items that will be contained in the returned page.
+//
+// Default value is `100`.
+func (r *RegistryCredentialsListResponse) GetSize() (value int, ok bool) {
+	ok = r != nil && r.size != nil
+	if ok {
+		value = *r.size
+	}
+	return
 }
 
 // Total returns the value of the 'total' parameter.
@@ -250,17 +278,45 @@ func (r *RegistryCredentialsListResponse) Size() int {
 // Total number of items of the collection that match the search criteria,
 // regardless of the size of the page.
 func (r *RegistryCredentialsListResponse) Total() int {
-	if r.total != nil {
+	if r != nil && r.total != nil {
 		return *r.total
 	}
 	return 0
+}
+
+// GetTotal returns the value of the 'total' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Total number of items of the collection that match the search criteria,
+// regardless of the size of the page.
+func (r *RegistryCredentialsListResponse) GetTotal() (value int, ok bool) {
+	ok = r != nil && r.total != nil
+	if ok {
+		value = *r.total
+	}
+	return
 }
 
 // Items returns the value of the 'items' parameter.
 //
 // Retrieved list of registry credentials.
 func (r *RegistryCredentialsListResponse) Items() *RegistryCredentialList {
+	if r == nil {
+		return nil
+	}
 	return r.items
+}
+
+// GetItems returns the value of the 'items' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Retrieved list of registry credentials.
+func (r *RegistryCredentialsListResponse) GetItems() (value *RegistryCredentialList, ok bool) {
+	ok = r != nil && r.items != nil
+	if ok {
+		value = r.items
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the
@@ -415,7 +471,22 @@ func (r *RegistryCredentialsAddResponse) Error() *errors.Error {
 //
 // Registry credential data.
 func (r *RegistryCredentialsAddResponse) Body() *RegistryCredential {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Registry credential data.
+func (r *RegistryCredentialsAddResponse) GetBody() (value *RegistryCredential, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/resource_quota_client.go
+++ b/pkg/client/accountsmgmt/v1/resource_quota_client.go
@@ -169,7 +169,22 @@ func (r *ResourceQuotaGetResponse) Error() *errors.Error {
 //
 //
 func (r *ResourceQuotaGetResponse) Body() *ResourceQuota {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *ResourceQuotaGetResponse) GetBody() (value *ResourceQuota, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the
@@ -312,7 +327,22 @@ func (r *ResourceQuotaUpdateResponse) Error() *errors.Error {
 //
 //
 func (r *ResourceQuotaUpdateResponse) Body() *ResourceQuota {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *ResourceQuotaUpdateResponse) GetBody() (value *ResourceQuota, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/resource_quotas_client.go
+++ b/pkg/client/accountsmgmt/v1/resource_quotas_client.go
@@ -227,10 +227,24 @@ func (r *ResourceQuotasListResponse) Error() *errors.Error {
 //
 // Default value is `1`.
 func (r *ResourceQuotasListResponse) Page() int {
-	if r.page != nil {
+	if r != nil && r.page != nil {
 		return *r.page
 	}
 	return 0
+}
+
+// GetPage returns the value of the 'page' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Index of the requested page, where one corresponds to the first page.
+//
+// Default value is `1`.
+func (r *ResourceQuotasListResponse) GetPage() (value int, ok bool) {
+	ok = r != nil && r.page != nil
+	if ok {
+		value = *r.page
+	}
+	return
 }
 
 // Size returns the value of the 'size' parameter.
@@ -239,10 +253,24 @@ func (r *ResourceQuotasListResponse) Page() int {
 //
 // Default value is `100`.
 func (r *ResourceQuotasListResponse) Size() int {
-	if r.size != nil {
+	if r != nil && r.size != nil {
 		return *r.size
 	}
 	return 0
+}
+
+// GetSize returns the value of the 'size' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Maximum number of items that will be contained in the returned page.
+//
+// Default value is `100`.
+func (r *ResourceQuotasListResponse) GetSize() (value int, ok bool) {
+	ok = r != nil && r.size != nil
+	if ok {
+		value = *r.size
+	}
+	return
 }
 
 // Total returns the value of the 'total' parameter.
@@ -250,17 +278,45 @@ func (r *ResourceQuotasListResponse) Size() int {
 // Total number of items of the collection that match the search criteria,
 // regardless of the size of the page.
 func (r *ResourceQuotasListResponse) Total() int {
-	if r.total != nil {
+	if r != nil && r.total != nil {
 		return *r.total
 	}
 	return 0
+}
+
+// GetTotal returns the value of the 'total' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Total number of items of the collection that match the search criteria,
+// regardless of the size of the page.
+func (r *ResourceQuotasListResponse) GetTotal() (value int, ok bool) {
+	ok = r != nil && r.total != nil
+	if ok {
+		value = *r.total
+	}
+	return
 }
 
 // Items returns the value of the 'items' parameter.
 //
 // Retrieved list of resource quotas.
 func (r *ResourceQuotasListResponse) Items() *ResourceQuotaList {
+	if r == nil {
+		return nil
+	}
 	return r.items
+}
+
+// GetItems returns the value of the 'items' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Retrieved list of resource quotas.
+func (r *ResourceQuotasListResponse) GetItems() (value *ResourceQuotaList, ok bool) {
+	ok = r != nil && r.items != nil
+	if ok {
+		value = r.items
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the
@@ -415,7 +471,22 @@ func (r *ResourceQuotasAddResponse) Error() *errors.Error {
 //
 // Resource quota data.
 func (r *ResourceQuotasAddResponse) Body() *ResourceQuota {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Resource quota data.
+func (r *ResourceQuotasAddResponse) GetBody() (value *ResourceQuota, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/role_binding_client.go
+++ b/pkg/client/accountsmgmt/v1/role_binding_client.go
@@ -167,7 +167,22 @@ func (r *RoleBindingGetResponse) Error() *errors.Error {
 //
 //
 func (r *RoleBindingGetResponse) Body() *RoleBinding {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *RoleBindingGetResponse) GetBody() (value *RoleBinding, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/role_bindings_client.go
+++ b/pkg/client/accountsmgmt/v1/role_bindings_client.go
@@ -227,10 +227,24 @@ func (r *RoleBindingsListResponse) Error() *errors.Error {
 //
 // Default value is `1`.
 func (r *RoleBindingsListResponse) Page() int {
-	if r.page != nil {
+	if r != nil && r.page != nil {
 		return *r.page
 	}
 	return 0
+}
+
+// GetPage returns the value of the 'page' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Index of the requested page, where one corresponds to the first page.
+//
+// Default value is `1`.
+func (r *RoleBindingsListResponse) GetPage() (value int, ok bool) {
+	ok = r != nil && r.page != nil
+	if ok {
+		value = *r.page
+	}
+	return
 }
 
 // Size returns the value of the 'size' parameter.
@@ -239,10 +253,24 @@ func (r *RoleBindingsListResponse) Page() int {
 //
 // Default value is `100`.
 func (r *RoleBindingsListResponse) Size() int {
-	if r.size != nil {
+	if r != nil && r.size != nil {
 		return *r.size
 	}
 	return 0
+}
+
+// GetSize returns the value of the 'size' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Maximum number of items that will be contained in the returned page.
+//
+// Default value is `100`.
+func (r *RoleBindingsListResponse) GetSize() (value int, ok bool) {
+	ok = r != nil && r.size != nil
+	if ok {
+		value = *r.size
+	}
+	return
 }
 
 // Total returns the value of the 'total' parameter.
@@ -250,17 +278,45 @@ func (r *RoleBindingsListResponse) Size() int {
 // Total number of items of the collection that match the search criteria,
 // regardless of the size of the page.
 func (r *RoleBindingsListResponse) Total() int {
-	if r.total != nil {
+	if r != nil && r.total != nil {
 		return *r.total
 	}
 	return 0
+}
+
+// GetTotal returns the value of the 'total' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Total number of items of the collection that match the search criteria,
+// regardless of the size of the page.
+func (r *RoleBindingsListResponse) GetTotal() (value int, ok bool) {
+	ok = r != nil && r.total != nil
+	if ok {
+		value = *r.total
+	}
+	return
 }
 
 // Items returns the value of the 'items' parameter.
 //
 // Retrieved list of role bindings.
 func (r *RoleBindingsListResponse) Items() *RoleBindingList {
+	if r == nil {
+		return nil
+	}
 	return r.items
+}
+
+// GetItems returns the value of the 'items' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Retrieved list of role bindings.
+func (r *RoleBindingsListResponse) GetItems() (value *RoleBindingList, ok bool) {
+	ok = r != nil && r.items != nil
+	if ok {
+		value = r.items
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the
@@ -415,7 +471,22 @@ func (r *RoleBindingsAddResponse) Error() *errors.Error {
 //
 // Role binding data.
 func (r *RoleBindingsAddResponse) Body() *RoleBinding {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Role binding data.
+func (r *RoleBindingsAddResponse) GetBody() (value *RoleBinding, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/role_client.go
+++ b/pkg/client/accountsmgmt/v1/role_client.go
@@ -180,7 +180,22 @@ func (r *RoleGetResponse) Error() *errors.Error {
 //
 //
 func (r *RoleGetResponse) Body() *Role {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *RoleGetResponse) GetBody() (value *Role, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the
@@ -323,7 +338,22 @@ func (r *RoleUpdateResponse) Error() *errors.Error {
 //
 //
 func (r *RoleUpdateResponse) Body() *Role {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *RoleUpdateResponse) GetBody() (value *Role, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/roles_client.go
+++ b/pkg/client/accountsmgmt/v1/roles_client.go
@@ -227,10 +227,24 @@ func (r *RolesListResponse) Error() *errors.Error {
 //
 // Default value is `1`.
 func (r *RolesListResponse) Page() int {
-	if r.page != nil {
+	if r != nil && r.page != nil {
 		return *r.page
 	}
 	return 0
+}
+
+// GetPage returns the value of the 'page' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Index of the requested page, where one corresponds to the first page.
+//
+// Default value is `1`.
+func (r *RolesListResponse) GetPage() (value int, ok bool) {
+	ok = r != nil && r.page != nil
+	if ok {
+		value = *r.page
+	}
+	return
 }
 
 // Size returns the value of the 'size' parameter.
@@ -239,10 +253,24 @@ func (r *RolesListResponse) Page() int {
 //
 // Default value is `100`.
 func (r *RolesListResponse) Size() int {
-	if r.size != nil {
+	if r != nil && r.size != nil {
 		return *r.size
 	}
 	return 0
+}
+
+// GetSize returns the value of the 'size' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Maximum number of items that will be contained in the returned page.
+//
+// Default value is `100`.
+func (r *RolesListResponse) GetSize() (value int, ok bool) {
+	ok = r != nil && r.size != nil
+	if ok {
+		value = *r.size
+	}
+	return
 }
 
 // Total returns the value of the 'total' parameter.
@@ -250,17 +278,45 @@ func (r *RolesListResponse) Size() int {
 // Total number of items of the collection that match the search criteria,
 // regardless of the size of the page.
 func (r *RolesListResponse) Total() int {
-	if r.total != nil {
+	if r != nil && r.total != nil {
 		return *r.total
 	}
 	return 0
+}
+
+// GetTotal returns the value of the 'total' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Total number of items of the collection that match the search criteria,
+// regardless of the size of the page.
+func (r *RolesListResponse) GetTotal() (value int, ok bool) {
+	ok = r != nil && r.total != nil
+	if ok {
+		value = *r.total
+	}
+	return
 }
 
 // Items returns the value of the 'items' parameter.
 //
 // Retrieved list of roles.
 func (r *RolesListResponse) Items() *RoleList {
+	if r == nil {
+		return nil
+	}
 	return r.items
+}
+
+// GetItems returns the value of the 'items' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Retrieved list of roles.
+func (r *RolesListResponse) GetItems() (value *RoleList, ok bool) {
+	ok = r != nil && r.items != nil
+	if ok {
+		value = r.items
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the
@@ -415,7 +471,22 @@ func (r *RolesAddResponse) Error() *errors.Error {
 //
 // Role data.
 func (r *RolesAddResponse) Body() *Role {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Role data.
+func (r *RolesAddResponse) GetBody() (value *Role, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/subscription_client.go
+++ b/pkg/client/accountsmgmt/v1/subscription_client.go
@@ -167,7 +167,22 @@ func (r *SubscriptionGetResponse) Error() *errors.Error {
 //
 //
 func (r *SubscriptionGetResponse) Body() *Subscription {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *SubscriptionGetResponse) GetBody() (value *Subscription, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/accountsmgmt/v1/subscriptions_client.go
+++ b/pkg/client/accountsmgmt/v1/subscriptions_client.go
@@ -214,10 +214,24 @@ func (r *SubscriptionsListResponse) Error() *errors.Error {
 //
 // Default value is `1`.
 func (r *SubscriptionsListResponse) Page() int {
-	if r.page != nil {
+	if r != nil && r.page != nil {
 		return *r.page
 	}
 	return 0
+}
+
+// GetPage returns the value of the 'page' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Index of the requested page, where one corresponds to the first page.
+//
+// Default value is `1`.
+func (r *SubscriptionsListResponse) GetPage() (value int, ok bool) {
+	ok = r != nil && r.page != nil
+	if ok {
+		value = *r.page
+	}
+	return
 }
 
 // Size returns the value of the 'size' parameter.
@@ -226,10 +240,24 @@ func (r *SubscriptionsListResponse) Page() int {
 //
 // Default value is `100`.
 func (r *SubscriptionsListResponse) Size() int {
-	if r.size != nil {
+	if r != nil && r.size != nil {
 		return *r.size
 	}
 	return 0
+}
+
+// GetSize returns the value of the 'size' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Maximum number of items that will be contained in the returned page.
+//
+// Default value is `100`.
+func (r *SubscriptionsListResponse) GetSize() (value int, ok bool) {
+	ok = r != nil && r.size != nil
+	if ok {
+		value = *r.size
+	}
+	return
 }
 
 // Total returns the value of the 'total' parameter.
@@ -237,17 +265,45 @@ func (r *SubscriptionsListResponse) Size() int {
 // Total number of items of the collection that match the search criteria,
 // regardless of the size of the page.
 func (r *SubscriptionsListResponse) Total() int {
-	if r.total != nil {
+	if r != nil && r.total != nil {
 		return *r.total
 	}
 	return 0
+}
+
+// GetTotal returns the value of the 'total' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Total number of items of the collection that match the search criteria,
+// regardless of the size of the page.
+func (r *SubscriptionsListResponse) GetTotal() (value int, ok bool) {
+	ok = r != nil && r.total != nil
+	if ok {
+		value = *r.total
+	}
+	return
 }
 
 // Items returns the value of the 'items' parameter.
 //
 // Retrieved list of subscriptions.
 func (r *SubscriptionsListResponse) Items() *SubscriptionList {
+	if r == nil {
+		return nil
+	}
 	return r.items
+}
+
+// GetItems returns the value of the 'items' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Retrieved list of subscriptions.
+func (r *SubscriptionsListResponse) GetItems() (value *SubscriptionList, ok bool) {
+	ok = r != nil && r.items != nil
+	if ok {
+		value = r.items
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/clustersmgmt/v1/cluster_client.go
+++ b/pkg/client/clustersmgmt/v1/cluster_client.go
@@ -236,7 +236,22 @@ func (r *ClusterGetResponse) Error() *errors.Error {
 //
 //
 func (r *ClusterGetResponse) Body() *Cluster {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *ClusterGetResponse) GetBody() (value *Cluster, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the
@@ -379,7 +394,22 @@ func (r *ClusterUpdateResponse) Error() *errors.Error {
 //
 //
 func (r *ClusterUpdateResponse) Body() *Cluster {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *ClusterUpdateResponse) GetBody() (value *Cluster, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/clustersmgmt/v1/cluster_status_client.go
+++ b/pkg/client/clustersmgmt/v1/cluster_status_client.go
@@ -156,7 +156,22 @@ func (r *ClusterStatusGetResponse) Error() *errors.Error {
 //
 //
 func (r *ClusterStatusGetResponse) Status_() *ClusterStatus {
+	if r == nil {
+		return nil
+	}
 	return r.status_
+}
+
+// GetStatus_ returns the value of the 'status' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *ClusterStatusGetResponse) GetStatus_() (value *ClusterStatus, ok bool) {
+	ok = r != nil && r.status_ != nil
+	if ok {
+		value = r.status_
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/clustersmgmt/v1/clusters_client.go
+++ b/pkg/client/clustersmgmt/v1/clusters_client.go
@@ -255,10 +255,24 @@ func (r *ClustersListResponse) Error() *errors.Error {
 //
 // Default value is `1`.
 func (r *ClustersListResponse) Page() int {
-	if r.page != nil {
+	if r != nil && r.page != nil {
 		return *r.page
 	}
 	return 0
+}
+
+// GetPage returns the value of the 'page' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Index of the requested page, where one corresponds to the first page.
+//
+// Default value is `1`.
+func (r *ClustersListResponse) GetPage() (value int, ok bool) {
+	ok = r != nil && r.page != nil
+	if ok {
+		value = *r.page
+	}
+	return
 }
 
 // Size returns the value of the 'size' parameter.
@@ -267,10 +281,24 @@ func (r *ClustersListResponse) Page() int {
 //
 // Default value is `100`.
 func (r *ClustersListResponse) Size() int {
-	if r.size != nil {
+	if r != nil && r.size != nil {
 		return *r.size
 	}
 	return 0
+}
+
+// GetSize returns the value of the 'size' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Maximum number of items that will be contained in the returned page.
+//
+// Default value is `100`.
+func (r *ClustersListResponse) GetSize() (value int, ok bool) {
+	ok = r != nil && r.size != nil
+	if ok {
+		value = *r.size
+	}
+	return
 }
 
 // Total returns the value of the 'total' parameter.
@@ -278,17 +306,45 @@ func (r *ClustersListResponse) Size() int {
 // Total number of items of the collection that match the search criteria,
 // regardless of the size of the page.
 func (r *ClustersListResponse) Total() int {
-	if r.total != nil {
+	if r != nil && r.total != nil {
 		return *r.total
 	}
 	return 0
+}
+
+// GetTotal returns the value of the 'total' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Total number of items of the collection that match the search criteria,
+// regardless of the size of the page.
+func (r *ClustersListResponse) GetTotal() (value int, ok bool) {
+	ok = r != nil && r.total != nil
+	if ok {
+		value = *r.total
+	}
+	return
 }
 
 // Items returns the value of the 'items' parameter.
 //
 // Retrieved list of clusters.
 func (r *ClustersListResponse) Items() *ClusterList {
+	if r == nil {
+		return nil
+	}
 	return r.items
+}
+
+// GetItems returns the value of the 'items' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Retrieved list of clusters.
+func (r *ClustersListResponse) GetItems() (value *ClusterList, ok bool) {
+	ok = r != nil && r.items != nil
+	if ok {
+		value = r.items
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the
@@ -443,7 +499,22 @@ func (r *ClustersAddResponse) Error() *errors.Error {
 //
 // Description of the cluster.
 func (r *ClustersAddResponse) Body() *Cluster {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Description of the cluster.
+func (r *ClustersAddResponse) GetBody() (value *Cluster, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/clustersmgmt/v1/credentials_client.go
+++ b/pkg/client/clustersmgmt/v1/credentials_client.go
@@ -156,7 +156,22 @@ func (r *CredentialsGetResponse) Error() *errors.Error {
 //
 //
 func (r *CredentialsGetResponse) Body() *ClusterCredentials {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *CredentialsGetResponse) GetBody() (value *ClusterCredentials, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/clustersmgmt/v1/dashboard_client.go
+++ b/pkg/client/clustersmgmt/v1/dashboard_client.go
@@ -156,7 +156,22 @@ func (r *DashboardGetResponse) Error() *errors.Error {
 //
 //
 func (r *DashboardGetResponse) Body() *Dashboard {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *DashboardGetResponse) GetBody() (value *Dashboard, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/clustersmgmt/v1/dashboards_client.go
+++ b/pkg/client/clustersmgmt/v1/dashboards_client.go
@@ -241,10 +241,24 @@ func (r *DashboardsListResponse) Error() *errors.Error {
 //
 // Default value is `1`.
 func (r *DashboardsListResponse) Page() int {
-	if r.page != nil {
+	if r != nil && r.page != nil {
 		return *r.page
 	}
 	return 0
+}
+
+// GetPage returns the value of the 'page' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Index of the requested page, where one corresponds to the first page.
+//
+// Default value is `1`.
+func (r *DashboardsListResponse) GetPage() (value int, ok bool) {
+	ok = r != nil && r.page != nil
+	if ok {
+		value = *r.page
+	}
+	return
 }
 
 // Size returns the value of the 'size' parameter.
@@ -253,10 +267,24 @@ func (r *DashboardsListResponse) Page() int {
 //
 // Default value is `100`.
 func (r *DashboardsListResponse) Size() int {
-	if r.size != nil {
+	if r != nil && r.size != nil {
 		return *r.size
 	}
 	return 0
+}
+
+// GetSize returns the value of the 'size' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Maximum number of items that will be contained in the returned page.
+//
+// Default value is `100`.
+func (r *DashboardsListResponse) GetSize() (value int, ok bool) {
+	ok = r != nil && r.size != nil
+	if ok {
+		value = *r.size
+	}
+	return
 }
 
 // Total returns the value of the 'total' parameter.
@@ -264,17 +292,45 @@ func (r *DashboardsListResponse) Size() int {
 // Total number of items of the collection that match the search criteria,
 // regardless of the size of the page.
 func (r *DashboardsListResponse) Total() int {
-	if r.total != nil {
+	if r != nil && r.total != nil {
 		return *r.total
 	}
 	return 0
+}
+
+// GetTotal returns the value of the 'total' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Total number of items of the collection that match the search criteria,
+// regardless of the size of the page.
+func (r *DashboardsListResponse) GetTotal() (value int, ok bool) {
+	ok = r != nil && r.total != nil
+	if ok {
+		value = *r.total
+	}
+	return
 }
 
 // Items returns the value of the 'items' parameter.
 //
 // Retrieved list of dashboards.
 func (r *DashboardsListResponse) Items() *DashboardList {
+	if r == nil {
+		return nil
+	}
 	return r.items
+}
+
+// GetItems returns the value of the 'items' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Retrieved list of dashboards.
+func (r *DashboardsListResponse) GetItems() (value *DashboardList, ok bool) {
+	ok = r != nil && r.items != nil
+	if ok {
+		value = r.items
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/clustersmgmt/v1/flavour_client.go
+++ b/pkg/client/clustersmgmt/v1/flavour_client.go
@@ -156,7 +156,22 @@ func (r *FlavourGetResponse) Error() *errors.Error {
 //
 //
 func (r *FlavourGetResponse) Body() *Flavour {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *FlavourGetResponse) GetBody() (value *Flavour, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/clustersmgmt/v1/flavours_client.go
+++ b/pkg/client/clustersmgmt/v1/flavours_client.go
@@ -252,10 +252,24 @@ func (r *FlavoursListResponse) Error() *errors.Error {
 //
 // Default value is `1`.
 func (r *FlavoursListResponse) Page() int {
-	if r.page != nil {
+	if r != nil && r.page != nil {
 		return *r.page
 	}
 	return 0
+}
+
+// GetPage returns the value of the 'page' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Index of the requested page, where one corresponds to the first page.
+//
+// Default value is `1`.
+func (r *FlavoursListResponse) GetPage() (value int, ok bool) {
+	ok = r != nil && r.page != nil
+	if ok {
+		value = *r.page
+	}
+	return
 }
 
 // Size returns the value of the 'size' parameter.
@@ -264,10 +278,24 @@ func (r *FlavoursListResponse) Page() int {
 //
 // Default value is `100`.
 func (r *FlavoursListResponse) Size() int {
-	if r.size != nil {
+	if r != nil && r.size != nil {
 		return *r.size
 	}
 	return 0
+}
+
+// GetSize returns the value of the 'size' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Maximum number of items that will be contained in the returned page.
+//
+// Default value is `100`.
+func (r *FlavoursListResponse) GetSize() (value int, ok bool) {
+	ok = r != nil && r.size != nil
+	if ok {
+		value = *r.size
+	}
+	return
 }
 
 // Total returns the value of the 'total' parameter.
@@ -275,17 +303,45 @@ func (r *FlavoursListResponse) Size() int {
 // Total number of items of the collection that match the search criteria,
 // regardless of the size of the page.
 func (r *FlavoursListResponse) Total() int {
-	if r.total != nil {
+	if r != nil && r.total != nil {
 		return *r.total
 	}
 	return 0
+}
+
+// GetTotal returns the value of the 'total' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Total number of items of the collection that match the search criteria,
+// regardless of the size of the page.
+func (r *FlavoursListResponse) GetTotal() (value int, ok bool) {
+	ok = r != nil && r.total != nil
+	if ok {
+		value = *r.total
+	}
+	return
 }
 
 // Items returns the value of the 'items' parameter.
 //
 // Retrieved list of flavours.
 func (r *FlavoursListResponse) Items() *FlavourList {
+	if r == nil {
+		return nil
+	}
 	return r.items
+}
+
+// GetItems returns the value of the 'items' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Retrieved list of flavours.
+func (r *FlavoursListResponse) GetItems() (value *FlavourList, ok bool) {
+	ok = r != nil && r.items != nil
+	if ok {
+		value = r.items
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the
@@ -440,7 +496,22 @@ func (r *FlavoursAddResponse) Error() *errors.Error {
 //
 // Details of the cluster flavour.
 func (r *FlavoursAddResponse) Body() *Flavour {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Details of the cluster flavour.
+func (r *FlavoursAddResponse) GetBody() (value *Flavour, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/clustersmgmt/v1/group_client.go
+++ b/pkg/client/clustersmgmt/v1/group_client.go
@@ -168,7 +168,22 @@ func (r *GroupGetResponse) Error() *errors.Error {
 //
 //
 func (r *GroupGetResponse) Body() *Group {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *GroupGetResponse) GetBody() (value *Group, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/clustersmgmt/v1/groups_client.go
+++ b/pkg/client/clustersmgmt/v1/groups_client.go
@@ -171,37 +171,88 @@ func (r *GroupsListResponse) Error() *errors.Error {
 //
 // Index of the requested page, where one corresponds to the first page.
 func (r *GroupsListResponse) Page() int {
-	if r.page != nil {
+	if r != nil && r.page != nil {
 		return *r.page
 	}
 	return 0
+}
+
+// GetPage returns the value of the 'page' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Index of the requested page, where one corresponds to the first page.
+func (r *GroupsListResponse) GetPage() (value int, ok bool) {
+	ok = r != nil && r.page != nil
+	if ok {
+		value = *r.page
+	}
+	return
 }
 
 // Size returns the value of the 'size' parameter.
 //
 // Number of items contained in the returned page.
 func (r *GroupsListResponse) Size() int {
-	if r.size != nil {
+	if r != nil && r.size != nil {
 		return *r.size
 	}
 	return 0
+}
+
+// GetSize returns the value of the 'size' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Number of items contained in the returned page.
+func (r *GroupsListResponse) GetSize() (value int, ok bool) {
+	ok = r != nil && r.size != nil
+	if ok {
+		value = *r.size
+	}
+	return
 }
 
 // Total returns the value of the 'total' parameter.
 //
 // Total number of items of the collection.
 func (r *GroupsListResponse) Total() int {
-	if r.total != nil {
+	if r != nil && r.total != nil {
 		return *r.total
 	}
 	return 0
+}
+
+// GetTotal returns the value of the 'total' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Total number of items of the collection.
+func (r *GroupsListResponse) GetTotal() (value int, ok bool) {
+	ok = r != nil && r.total != nil
+	if ok {
+		value = *r.total
+	}
+	return
 }
 
 // Items returns the value of the 'items' parameter.
 //
 // Retrieved list of groups.
 func (r *GroupsListResponse) Items() *GroupList {
+	if r == nil {
+		return nil
+	}
 	return r.items
+}
+
+// GetItems returns the value of the 'items' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Retrieved list of groups.
+func (r *GroupsListResponse) GetItems() (value *GroupList, ok bool) {
+	ok = r != nil && r.items != nil
+	if ok {
+		value = r.items
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/clustersmgmt/v1/identity_provider_client.go
+++ b/pkg/client/clustersmgmt/v1/identity_provider_client.go
@@ -167,7 +167,22 @@ func (r *IdentityProviderGetResponse) Error() *errors.Error {
 //
 //
 func (r *IdentityProviderGetResponse) Body() *IdentityProvider {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *IdentityProviderGetResponse) GetBody() (value *IdentityProvider, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/clustersmgmt/v1/identity_providers_client.go
+++ b/pkg/client/clustersmgmt/v1/identity_providers_client.go
@@ -184,37 +184,88 @@ func (r *IdentityProvidersListResponse) Error() *errors.Error {
 //
 // Index of the requested page, where one corresponds to the first page.
 func (r *IdentityProvidersListResponse) Page() int {
-	if r.page != nil {
+	if r != nil && r.page != nil {
 		return *r.page
 	}
 	return 0
+}
+
+// GetPage returns the value of the 'page' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Index of the requested page, where one corresponds to the first page.
+func (r *IdentityProvidersListResponse) GetPage() (value int, ok bool) {
+	ok = r != nil && r.page != nil
+	if ok {
+		value = *r.page
+	}
+	return
 }
 
 // Size returns the value of the 'size' parameter.
 //
 // Number of items contained in the returned page.
 func (r *IdentityProvidersListResponse) Size() int {
-	if r.size != nil {
+	if r != nil && r.size != nil {
 		return *r.size
 	}
 	return 0
+}
+
+// GetSize returns the value of the 'size' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Number of items contained in the returned page.
+func (r *IdentityProvidersListResponse) GetSize() (value int, ok bool) {
+	ok = r != nil && r.size != nil
+	if ok {
+		value = *r.size
+	}
+	return
 }
 
 // Total returns the value of the 'total' parameter.
 //
 // Total number of items of the collection.
 func (r *IdentityProvidersListResponse) Total() int {
-	if r.total != nil {
+	if r != nil && r.total != nil {
 		return *r.total
 	}
 	return 0
+}
+
+// GetTotal returns the value of the 'total' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Total number of items of the collection.
+func (r *IdentityProvidersListResponse) GetTotal() (value int, ok bool) {
+	ok = r != nil && r.total != nil
+	if ok {
+		value = *r.total
+	}
+	return
 }
 
 // Items returns the value of the 'items' parameter.
 //
 // Retrieved list of identity providers.
 func (r *IdentityProvidersListResponse) Items() *IdentityProviderList {
+	if r == nil {
+		return nil
+	}
 	return r.items
+}
+
+// GetItems returns the value of the 'items' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Retrieved list of identity providers.
+func (r *IdentityProvidersListResponse) GetItems() (value *IdentityProviderList, ok bool) {
+	ok = r != nil && r.items != nil
+	if ok {
+		value = r.items
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the
@@ -369,7 +420,22 @@ func (r *IdentityProvidersAddResponse) Error() *errors.Error {
 //
 // Description of the cluster.
 func (r *IdentityProvidersAddResponse) Body() *IdentityProvider {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Description of the cluster.
+func (r *IdentityProvidersAddResponse) GetBody() (value *IdentityProvider, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/clustersmgmt/v1/log_client.go
+++ b/pkg/client/clustersmgmt/v1/log_client.go
@@ -156,7 +156,22 @@ func (r *LogGetResponse) Error() *errors.Error {
 //
 //
 func (r *LogGetResponse) Body() *Log {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *LogGetResponse) GetBody() (value *Log, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/clustersmgmt/v1/logs_client.go
+++ b/pkg/client/clustersmgmt/v1/logs_client.go
@@ -171,37 +171,88 @@ func (r *LogsListResponse) Error() *errors.Error {
 //
 // Index of the requested page, where one corresponds to the first page.
 func (r *LogsListResponse) Page() int {
-	if r.page != nil {
+	if r != nil && r.page != nil {
 		return *r.page
 	}
 	return 0
+}
+
+// GetPage returns the value of the 'page' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Index of the requested page, where one corresponds to the first page.
+func (r *LogsListResponse) GetPage() (value int, ok bool) {
+	ok = r != nil && r.page != nil
+	if ok {
+		value = *r.page
+	}
+	return
 }
 
 // Size returns the value of the 'size' parameter.
 //
 // Number of items contained in the returned page.
 func (r *LogsListResponse) Size() int {
-	if r.size != nil {
+	if r != nil && r.size != nil {
 		return *r.size
 	}
 	return 0
+}
+
+// GetSize returns the value of the 'size' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Number of items contained in the returned page.
+func (r *LogsListResponse) GetSize() (value int, ok bool) {
+	ok = r != nil && r.size != nil
+	if ok {
+		value = *r.size
+	}
+	return
 }
 
 // Total returns the value of the 'total' parameter.
 //
 // Total number of items of the collection.
 func (r *LogsListResponse) Total() int {
-	if r.total != nil {
+	if r != nil && r.total != nil {
 		return *r.total
 	}
 	return 0
+}
+
+// GetTotal returns the value of the 'total' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Total number of items of the collection.
+func (r *LogsListResponse) GetTotal() (value int, ok bool) {
+	ok = r != nil && r.total != nil
+	if ok {
+		value = *r.total
+	}
+	return
 }
 
 // Items returns the value of the 'items' parameter.
 //
 // Retrieved list of logs.
 func (r *LogsListResponse) Items() *LogList {
+	if r == nil {
+		return nil
+	}
 	return r.items
+}
+
+// GetItems returns the value of the 'items' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Retrieved list of logs.
+func (r *LogsListResponse) GetItems() (value *LogList, ok bool) {
+	ok = r != nil && r.items != nil
+	if ok {
+		value = r.items
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/clustersmgmt/v1/user_client.go
+++ b/pkg/client/clustersmgmt/v1/user_client.go
@@ -167,7 +167,22 @@ func (r *UserGetResponse) Error() *errors.Error {
 //
 //
 func (r *UserGetResponse) Body() *User {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *UserGetResponse) GetBody() (value *User, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/clustersmgmt/v1/users_client.go
+++ b/pkg/client/clustersmgmt/v1/users_client.go
@@ -184,37 +184,88 @@ func (r *UsersListResponse) Error() *errors.Error {
 //
 // Index of the requested page, where one corresponds to the first page.
 func (r *UsersListResponse) Page() int {
-	if r.page != nil {
+	if r != nil && r.page != nil {
 		return *r.page
 	}
 	return 0
+}
+
+// GetPage returns the value of the 'page' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Index of the requested page, where one corresponds to the first page.
+func (r *UsersListResponse) GetPage() (value int, ok bool) {
+	ok = r != nil && r.page != nil
+	if ok {
+		value = *r.page
+	}
+	return
 }
 
 // Size returns the value of the 'size' parameter.
 //
 // Number of items contained in the returned page.
 func (r *UsersListResponse) Size() int {
-	if r.size != nil {
+	if r != nil && r.size != nil {
 		return *r.size
 	}
 	return 0
+}
+
+// GetSize returns the value of the 'size' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Number of items contained in the returned page.
+func (r *UsersListResponse) GetSize() (value int, ok bool) {
+	ok = r != nil && r.size != nil
+	if ok {
+		value = *r.size
+	}
+	return
 }
 
 // Total returns the value of the 'total' parameter.
 //
 // Total number of items of the collection.
 func (r *UsersListResponse) Total() int {
-	if r.total != nil {
+	if r != nil && r.total != nil {
 		return *r.total
 	}
 	return 0
+}
+
+// GetTotal returns the value of the 'total' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Total number of items of the collection.
+func (r *UsersListResponse) GetTotal() (value int, ok bool) {
+	ok = r != nil && r.total != nil
+	if ok {
+		value = *r.total
+	}
+	return
 }
 
 // Items returns the value of the 'items' parameter.
 //
 // Retrieved list of users.
 func (r *UsersListResponse) Items() *UserList {
+	if r == nil {
+		return nil
+	}
 	return r.items
+}
+
+// GetItems returns the value of the 'items' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Retrieved list of users.
+func (r *UsersListResponse) GetItems() (value *UserList, ok bool) {
+	ok = r != nil && r.items != nil
+	if ok {
+		value = r.items
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the
@@ -369,7 +420,22 @@ func (r *UsersAddResponse) Error() *errors.Error {
 //
 // Description of the user.
 func (r *UsersAddResponse) Body() *User {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Description of the user.
+func (r *UsersAddResponse) GetBody() (value *User, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/clustersmgmt/v1/version_client.go
+++ b/pkg/client/clustersmgmt/v1/version_client.go
@@ -156,7 +156,22 @@ func (r *VersionGetResponse) Error() *errors.Error {
 //
 //
 func (r *VersionGetResponse) Body() *Version {
+	if r == nil {
+		return nil
+	}
 	return r.body
+}
+
+// GetBody returns the value of the 'body' parameter and
+// a flag indicating if the parameter has a value.
+//
+//
+func (r *VersionGetResponse) GetBody() (value *Version, ok bool) {
+	ok = r != nil && r.body != nil
+	if ok {
+		value = r.body
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the

--- a/pkg/client/clustersmgmt/v1/versions_client.go
+++ b/pkg/client/clustersmgmt/v1/versions_client.go
@@ -239,10 +239,24 @@ func (r *VersionsListResponse) Error() *errors.Error {
 //
 // Default value is `1`.
 func (r *VersionsListResponse) Page() int {
-	if r.page != nil {
+	if r != nil && r.page != nil {
 		return *r.page
 	}
 	return 0
+}
+
+// GetPage returns the value of the 'page' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Index of the requested page, where one corresponds to the first page.
+//
+// Default value is `1`.
+func (r *VersionsListResponse) GetPage() (value int, ok bool) {
+	ok = r != nil && r.page != nil
+	if ok {
+		value = *r.page
+	}
+	return
 }
 
 // Size returns the value of the 'size' parameter.
@@ -251,10 +265,24 @@ func (r *VersionsListResponse) Page() int {
 //
 // Default value is `100`.
 func (r *VersionsListResponse) Size() int {
-	if r.size != nil {
+	if r != nil && r.size != nil {
 		return *r.size
 	}
 	return 0
+}
+
+// GetSize returns the value of the 'size' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Maximum number of items that will be contained in the returned page.
+//
+// Default value is `100`.
+func (r *VersionsListResponse) GetSize() (value int, ok bool) {
+	ok = r != nil && r.size != nil
+	if ok {
+		value = *r.size
+	}
+	return
 }
 
 // Total returns the value of the 'total' parameter.
@@ -262,17 +290,45 @@ func (r *VersionsListResponse) Size() int {
 // Total number of items of the collection that match the search criteria,
 // regardless of the size of the page.
 func (r *VersionsListResponse) Total() int {
-	if r.total != nil {
+	if r != nil && r.total != nil {
 		return *r.total
 	}
 	return 0
+}
+
+// GetTotal returns the value of the 'total' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Total number of items of the collection that match the search criteria,
+// regardless of the size of the page.
+func (r *VersionsListResponse) GetTotal() (value int, ok bool) {
+	ok = r != nil && r.total != nil
+	if ok {
+		value = *r.total
+	}
+	return
 }
 
 // Items returns the value of the 'items' parameter.
 //
 // Retrieved list of versions.
 func (r *VersionsListResponse) Items() *VersionList {
+	if r == nil {
+		return nil
+	}
 	return r.items
+}
+
+// GetItems returns the value of the 'items' parameter and
+// a flag indicating if the parameter has a value.
+//
+// Retrieved list of versions.
+func (r *VersionsListResponse) GetItems() (value *VersionList, ok bool) {
+	ok = r != nil && r.items != nil
+	if ok {
+		value = r.items
+	}
+	return
 }
 
 // unmarshal is the method used internally to unmarshal responses to the


### PR DESCRIPTION
Currently the response objects don't have getters that return the value
of the parameter and the presence flag. This patch adds them.