### PR TITLE
Add get by index

### DIFF
--- a/pkg/client/accountsmgmt/v1/access_token_type.go
+++ b/pkg/client/accountsmgmt/v1/access_token_type.go
@@ -48,6 +48,15 @@ func (l *AccessTokenList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AccessTokenList) Get(i int) *AccessToken {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/accountsmgmt/v1/account_type.go
+++ b/pkg/client/accountsmgmt/v1/account_type.go
@@ -364,6 +364,15 @@ func (l *AccountList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AccountList) Get(i int) *Account {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/accountsmgmt/v1/cluster_authorization_request_type.go
+++ b/pkg/client/accountsmgmt/v1/cluster_authorization_request_type.go
@@ -223,6 +223,15 @@ func (l *ClusterAuthorizationRequestList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ClusterAuthorizationRequestList) Get(i int) *ClusterAuthorizationRequest {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/accountsmgmt/v1/cluster_authorization_response_type.go
+++ b/pkg/client/accountsmgmt/v1/cluster_authorization_response_type.go
@@ -123,6 +123,15 @@ func (l *ClusterAuthorizationResponseList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ClusterAuthorizationResponseList) Get(i int) *ClusterAuthorizationResponse {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/accountsmgmt/v1/cluster_registration_request_type.go
+++ b/pkg/client/accountsmgmt/v1/cluster_registration_request_type.go
@@ -98,6 +98,15 @@ func (l *ClusterRegistrationRequestList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ClusterRegistrationRequestList) Get(i int) *ClusterRegistrationRequest {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/accountsmgmt/v1/cluster_registration_response_type.go
+++ b/pkg/client/accountsmgmt/v1/cluster_registration_response_type.go
@@ -152,6 +152,15 @@ func (l *ClusterRegistrationResponseList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ClusterRegistrationResponseList) Get(i int) *ClusterRegistrationResponse {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/accountsmgmt/v1/organization_type.go
+++ b/pkg/client/accountsmgmt/v1/organization_type.go
@@ -189,6 +189,15 @@ func (l *OrganizationList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *OrganizationList) Get(i int) *Organization {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/accountsmgmt/v1/permission_type.go
+++ b/pkg/client/accountsmgmt/v1/permission_type.go
@@ -239,6 +239,15 @@ func (l *PermissionList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *PermissionList) Get(i int) *Permission {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/accountsmgmt/v1/plan_type.go
+++ b/pkg/client/accountsmgmt/v1/plan_type.go
@@ -164,6 +164,15 @@ func (l *PlanList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *PlanList) Get(i int) *Plan {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/accountsmgmt/v1/registry_credential_type.go
+++ b/pkg/client/accountsmgmt/v1/registry_credential_type.go
@@ -264,6 +264,15 @@ func (l *RegistryCredentialList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *RegistryCredentialList) Get(i int) *RegistryCredential {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/accountsmgmt/v1/registry_type.go
+++ b/pkg/client/accountsmgmt/v1/registry_type.go
@@ -314,6 +314,15 @@ func (l *RegistryList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *RegistryList) Get(i int) *Registry {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/accountsmgmt/v1/reserved_resource_type.go
+++ b/pkg/client/accountsmgmt/v1/reserved_resource_type.go
@@ -173,6 +173,15 @@ func (l *ReservedResourceList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ReservedResourceList) Get(i int) *ReservedResource {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/accountsmgmt/v1/resource_quota_type.go
+++ b/pkg/client/accountsmgmt/v1/resource_quota_type.go
@@ -364,6 +364,15 @@ func (l *ResourceQuotaList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ResourceQuotaList) Get(i int) *ResourceQuota {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/accountsmgmt/v1/role_binding_type.go
+++ b/pkg/client/accountsmgmt/v1/role_binding_type.go
@@ -289,6 +289,15 @@ func (l *RoleBindingList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *RoleBindingList) Get(i int) *RoleBinding {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/accountsmgmt/v1/role_type.go
+++ b/pkg/client/accountsmgmt/v1/role_type.go
@@ -214,6 +214,15 @@ func (l *RoleList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *RoleList) Get(i int) *Role {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/accountsmgmt/v1/subscription_type.go
+++ b/pkg/client/accountsmgmt/v1/subscription_type.go
@@ -343,6 +343,15 @@ func (l *SubscriptionList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *SubscriptionList) Get(i int) *Subscription {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/admin_credentials_type.go
+++ b/pkg/client/clustersmgmt/v1/admin_credentials_type.go
@@ -99,6 +99,15 @@ func (l *AdminCredentialsList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AdminCredentialsList) Get(i int) *AdminCredentials {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/aws_type.go
+++ b/pkg/client/clustersmgmt/v1/aws_type.go
@@ -98,6 +98,15 @@ func (l *AWSList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AWSList) Get(i int) *AWS {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/cloud_provider_type.go
+++ b/pkg/client/clustersmgmt/v1/cloud_provider_type.go
@@ -100,6 +100,15 @@ func (l *CloudProviderList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *CloudProviderList) Get(i int) *CloudProvider {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/cloud_region_type.go
+++ b/pkg/client/clustersmgmt/v1/cloud_region_type.go
@@ -245,6 +245,15 @@ func (l *CloudRegionList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *CloudRegionList) Get(i int) *CloudRegion {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/cluster_api_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_api_type.go
@@ -73,6 +73,15 @@ func (l *ClusterAPIList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ClusterAPIList) Get(i int) *ClusterAPI {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/cluster_console_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_console_type.go
@@ -73,6 +73,15 @@ func (l *ClusterConsoleList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ClusterConsoleList) Get(i int) *ClusterConsole {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/cluster_credentials_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_credentials_type.go
@@ -241,6 +241,15 @@ func (l *ClusterCredentialsList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ClusterCredentialsList) Get(i int) *ClusterCredentials {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/cluster_metric_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_metric_type.go
@@ -132,6 +132,15 @@ func (l *ClusterMetricList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ClusterMetricList) Get(i int) *ClusterMetric {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/cluster_metrics_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_metrics_type.go
@@ -152,6 +152,15 @@ func (l *ClusterMetricsList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ClusterMetricsList) Get(i int) *ClusterMetrics {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/cluster_nodes_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_nodes_type.go
@@ -148,6 +148,15 @@ func (l *ClusterNodesList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ClusterNodesList) Get(i int) *ClusterNodes {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/cluster_registration_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_registration_type.go
@@ -134,6 +134,15 @@ func (l *ClusterRegistrationList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ClusterRegistrationList) Get(i int) *ClusterRegistration {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/cluster_status_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_status_type.go
@@ -214,6 +214,15 @@ func (l *ClusterStatusList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ClusterStatusList) Get(i int) *ClusterStatus {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/cluster_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_type.go
@@ -832,6 +832,15 @@ func (l *ClusterList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ClusterList) Get(i int) *Cluster {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/dashboard_type.go
+++ b/pkg/client/clustersmgmt/v1/dashboard_type.go
@@ -189,6 +189,15 @@ func (l *DashboardList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *DashboardList) Get(i int) *Dashboard {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/dns_type.go
+++ b/pkg/client/clustersmgmt/v1/dns_type.go
@@ -159,6 +159,15 @@ func (l *DNSList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *DNSList) Get(i int) *DNS {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/flavour_type.go
+++ b/pkg/client/clustersmgmt/v1/flavour_type.go
@@ -310,6 +310,15 @@ func (l *FlavourList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *FlavourList) Get(i int) *Flavour {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/github_identity_provider_type.go
+++ b/pkg/client/clustersmgmt/v1/github_identity_provider_type.go
@@ -156,6 +156,15 @@ func (l *GithubIdentityProviderList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *GithubIdentityProviderList) Get(i int) *GithubIdentityProvider {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/gitlab_identity_provider_type.go
+++ b/pkg/client/clustersmgmt/v1/gitlab_identity_provider_type.go
@@ -148,6 +148,15 @@ func (l *GitlabIdentityProviderList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *GitlabIdentityProviderList) Get(i int) *GitlabIdentityProvider {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/google_identity_provider_type.go
+++ b/pkg/client/clustersmgmt/v1/google_identity_provider_type.go
@@ -123,6 +123,15 @@ func (l *GoogleIdentityProviderList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *GoogleIdentityProviderList) Get(i int) *GoogleIdentityProvider {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/group_type.go
+++ b/pkg/client/clustersmgmt/v1/group_type.go
@@ -189,6 +189,15 @@ func (l *GroupList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *GroupList) Get(i int) *Group {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/identity_provider_type.go
+++ b/pkg/client/clustersmgmt/v1/identity_provider_type.go
@@ -424,6 +424,15 @@ func (l *IdentityProviderList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *IdentityProviderList) Get(i int) *IdentityProvider {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/ldapattributes_type.go
+++ b/pkg/client/clustersmgmt/v1/ldapattributes_type.go
@@ -148,6 +148,15 @@ func (l *LdapattributesList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *LdapattributesList) Get(i int) *Ldapattributes {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/ldapidentity_provider_type.go
+++ b/pkg/client/clustersmgmt/v1/ldapidentity_provider_type.go
@@ -202,6 +202,15 @@ func (l *LdapidentityProviderList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *LdapidentityProviderList) Get(i int) *LdapidentityProvider {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/log_type.go
+++ b/pkg/client/clustersmgmt/v1/log_type.go
@@ -189,6 +189,15 @@ func (l *LogList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *LogList) Get(i int) *Log {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/metric_type.go
+++ b/pkg/client/clustersmgmt/v1/metric_type.go
@@ -98,6 +98,15 @@ func (l *MetricList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *MetricList) Get(i int) *Metric {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/network_type.go
+++ b/pkg/client/clustersmgmt/v1/network_type.go
@@ -123,6 +123,15 @@ func (l *NetworkList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *NetworkList) Get(i int) *Network {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/open_idclaims_type.go
+++ b/pkg/client/clustersmgmt/v1/open_idclaims_type.go
@@ -123,6 +123,15 @@ func (l *OpenIdclaimsList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *OpenIdclaimsList) Get(i int) *OpenIdclaims {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/open_ididentity_provider_type.go
+++ b/pkg/client/clustersmgmt/v1/open_ididentity_provider_type.go
@@ -225,6 +225,15 @@ func (l *OpenIdidentityProviderList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *OpenIdidentityProviderList) Get(i int) *OpenIdidentityProvider {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/open_idurls_type.go
+++ b/pkg/client/clustersmgmt/v1/open_idurls_type.go
@@ -123,6 +123,15 @@ func (l *OpenIdurlsList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *OpenIdurlsList) Get(i int) *OpenIdurls {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/sample_type.go
+++ b/pkg/client/clustersmgmt/v1/sample_type.go
@@ -102,6 +102,15 @@ func (l *SampleList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *SampleList) Get(i int) *Sample {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/sshcredentials_type.go
+++ b/pkg/client/clustersmgmt/v1/sshcredentials_type.go
@@ -98,6 +98,15 @@ func (l *SshcredentialsList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *SshcredentialsList) Get(i int) *Sshcredentials {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/subscription_type.go
+++ b/pkg/client/clustersmgmt/v1/subscription_type.go
@@ -164,6 +164,15 @@ func (l *SubscriptionList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *SubscriptionList) Get(i int) *Subscription {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/user_type.go
+++ b/pkg/client/clustersmgmt/v1/user_type.go
@@ -164,6 +164,15 @@ func (l *UserList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *UserList) Get(i int) *User {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/value_type.go
+++ b/pkg/client/clustersmgmt/v1/value_type.go
@@ -115,6 +115,15 @@ func (l *ValueList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ValueList) Get(i int) *Value {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.

--- a/pkg/client/clustersmgmt/v1/version_type.go
+++ b/pkg/client/clustersmgmt/v1/version_type.go
@@ -216,6 +216,15 @@ func (l *VersionList) Empty() bool {
 	return l == nil || len(l.items) == 0
 }
 
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *VersionList) Get(i int) *Version {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
 // Slice returns an slice containing the items of the list. The returned slice is a
 // copy of the one used internally, so it can be modified without affecting the
 // internal representation.


### PR DESCRIPTION
This patch adds a `Get` method to lists that returns an element for a
given index.