### PR TITLE
Add cluster `expiration_timestamp`

### DIFF
--- a/pkg/client/clustersmgmt/v1/cluster_builder.go
+++ b/pkg/client/clustersmgmt/v1/cluster_builder.go
@@ -63,33 +63,34 @@ import (
 // attributes are mandatory when creation a cluster with your own Amazon Web
 // Services account.
 type ClusterBuilder struct {
-	id                *string
-	href              *string
-	link              bool
-	name              *string
-	flavour           *FlavourBuilder
-	console           *ClusterConsoleBuilder
-	multiAZ           *bool
-	nodes             *ClusterNodesBuilder
-	api               *ClusterAPIBuilder
-	region            *CloudRegionBuilder
-	displayName       *string
-	dns               *DNSBuilder
-	properties        map[string]string
-	state             *ClusterState
-	managed           *bool
-	externalID        *string
-	aws               *AWSBuilder
-	network           *NetworkBuilder
-	creationTimestamp *time.Time
-	cloudProvider     *CloudProviderBuilder
-	openshiftVersion  *string
-	subscription      *SubscriptionBuilder
-	groups            []*GroupBuilder
-	creator           *string
-	version           *VersionBuilder
-	identityProviders []*IdentityProviderBuilder
-	metrics           *ClusterMetricsBuilder
+	id                  *string
+	href                *string
+	link                bool
+	name                *string
+	flavour             *FlavourBuilder
+	console             *ClusterConsoleBuilder
+	multiAZ             *bool
+	nodes               *ClusterNodesBuilder
+	api                 *ClusterAPIBuilder
+	region              *CloudRegionBuilder
+	displayName         *string
+	dns                 *DNSBuilder
+	properties          map[string]string
+	state               *ClusterState
+	managed             *bool
+	externalID          *string
+	aws                 *AWSBuilder
+	network             *NetworkBuilder
+	creationTimestamp   *time.Time
+	expirationTimestamp *time.Time
+	cloudProvider       *CloudProviderBuilder
+	openshiftVersion    *string
+	subscription        *SubscriptionBuilder
+	groups              []*GroupBuilder
+	creator             *string
+	version             *VersionBuilder
+	identityProviders   []*IdentityProviderBuilder
+	metrics             *ClusterMetricsBuilder
 }
 
 // NewCluster creates a new builder of 'cluster' objects.
@@ -260,6 +261,15 @@ func (b *ClusterBuilder) CreationTimestamp(value time.Time) *ClusterBuilder {
 	return b
 }
 
+// ExpirationTimestamp sets the value of the 'expiration_timestamp' attribute
+// to the given value.
+//
+//
+func (b *ClusterBuilder) ExpirationTimestamp(value time.Time) *ClusterBuilder {
+	b.expirationTimestamp = &value
+	return b
+}
+
 // CloudProvider sets the value of the 'cloud_provider' attribute
 // to the given value.
 //
@@ -411,6 +421,9 @@ func (b *ClusterBuilder) Build() (object *Cluster, err error) {
 	}
 	if b.creationTimestamp != nil {
 		object.creationTimestamp = b.creationTimestamp
+	}
+	if b.expirationTimestamp != nil {
+		object.expirationTimestamp = b.expirationTimestamp
 	}
 	if b.cloudProvider != nil {
 		object.cloudProvider, err = b.cloudProvider.Build()

--- a/pkg/client/clustersmgmt/v1/cluster_reader.go
+++ b/pkg/client/clustersmgmt/v1/cluster_reader.go
@@ -29,33 +29,34 @@ import (
 // clusterData is the data structure used internally to marshal and unmarshal
 // objects of type 'cluster'.
 type clusterData struct {
-	Kind              *string                       "json:\"kind,omitempty\""
-	ID                *string                       "json:\"id,omitempty\""
-	HREF              *string                       "json:\"href,omitempty\""
-	Name              *string                       "json:\"name,omitempty\""
-	Flavour           *flavourData                  "json:\"flavour,omitempty\""
-	Console           *clusterConsoleData           "json:\"console,omitempty\""
-	MultiAZ           *bool                         "json:\"multi_az,omitempty\""
-	Nodes             *clusterNodesData             "json:\"nodes,omitempty\""
-	API               *clusterAPIData               "json:\"api,omitempty\""
-	Region            *cloudRegionData              "json:\"region,omitempty\""
-	DisplayName       *string                       "json:\"display_name,omitempty\""
-	DNS               *dnsData                      "json:\"dns,omitempty\""
-	Properties        map[string]string             "json:\"properties,omitempty\""
-	State             *ClusterState                 "json:\"state,omitempty\""
-	Managed           *bool                         "json:\"managed,omitempty\""
-	ExternalID        *string                       "json:\"external_id,omitempty\""
-	AWS               *awsData                      "json:\"aws,omitempty\""
-	Network           *networkData                  "json:\"network,omitempty\""
-	CreationTimestamp *time.Time                    "json:\"creation_timestamp,omitempty\""
-	CloudProvider     *cloudProviderData            "json:\"cloud_provider,omitempty\""
-	OpenshiftVersion  *string                       "json:\"openshift_version,omitempty\""
-	Subscription      *subscriptionData             "json:\"subscription,omitempty\""
-	Groups            *groupListLinkData            "json:\"groups,omitempty\""
-	Creator           *string                       "json:\"creator,omitempty\""
-	Version           *versionData                  "json:\"version,omitempty\""
-	IdentityProviders *identityProviderListLinkData "json:\"identity_providers,omitempty\""
-	Metrics           *clusterMetricsData           "json:\"metrics,omitempty\""
+	Kind                *string                       "json:\"kind,omitempty\""
+	ID                  *string                       "json:\"id,omitempty\""
+	HREF                *string                       "json:\"href,omitempty\""
+	Name                *string                       "json:\"name,omitempty\""
+	Flavour             *flavourData                  "json:\"flavour,omitempty\""
+	Console             *clusterConsoleData           "json:\"console,omitempty\""
+	MultiAZ             *bool                         "json:\"multi_az,omitempty\""
+	Nodes               *clusterNodesData             "json:\"nodes,omitempty\""
+	API                 *clusterAPIData               "json:\"api,omitempty\""
+	Region              *cloudRegionData              "json:\"region,omitempty\""
+	DisplayName         *string                       "json:\"display_name,omitempty\""
+	DNS                 *dnsData                      "json:\"dns,omitempty\""
+	Properties          map[string]string             "json:\"properties,omitempty\""
+	State               *ClusterState                 "json:\"state,omitempty\""
+	Managed             *bool                         "json:\"managed,omitempty\""
+	ExternalID          *string                       "json:\"external_id,omitempty\""
+	AWS                 *awsData                      "json:\"aws,omitempty\""
+	Network             *networkData                  "json:\"network,omitempty\""
+	CreationTimestamp   *time.Time                    "json:\"creation_timestamp,omitempty\""
+	ExpirationTimestamp *time.Time                    "json:\"expiration_timestamp,omitempty\""
+	CloudProvider       *cloudProviderData            "json:\"cloud_provider,omitempty\""
+	OpenshiftVersion    *string                       "json:\"openshift_version,omitempty\""
+	Subscription        *subscriptionData             "json:\"subscription,omitempty\""
+	Groups              *groupListLinkData            "json:\"groups,omitempty\""
+	Creator             *string                       "json:\"creator,omitempty\""
+	Version             *versionData                  "json:\"version,omitempty\""
+	IdentityProviders   *identityProviderListLinkData "json:\"identity_providers,omitempty\""
+	Metrics             *clusterMetricsData           "json:\"metrics,omitempty\""
 }
 
 // MarshalCluster writes a value of the 'cluster' to the given target,
@@ -127,6 +128,7 @@ func (o *Cluster) wrap() (data *clusterData, err error) {
 		return
 	}
 	data.CreationTimestamp = o.creationTimestamp
+	data.ExpirationTimestamp = o.expirationTimestamp
 	data.CloudProvider, err = o.cloudProvider.wrap()
 	if err != nil {
 		return
@@ -237,6 +239,7 @@ func (d *clusterData) unwrap() (object *Cluster, err error) {
 		return
 	}
 	object.creationTimestamp = d.CreationTimestamp
+	object.expirationTimestamp = d.ExpirationTimestamp
 	object.cloudProvider, err = d.CloudProvider.unwrap()
 	if err != nil {
 		return

--- a/pkg/client/clustersmgmt/v1/cluster_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_type.go
@@ -75,33 +75,34 @@ const ClusterNilKind = "ClusterNil"
 // attributes are mandatory when creation a cluster with your own Amazon Web
 // Services account.
 type Cluster struct {
-	id                *string
-	href              *string
-	link              bool
-	name              *string
-	flavour           *Flavour
-	console           *ClusterConsole
-	multiAZ           *bool
-	nodes             *ClusterNodes
-	api               *ClusterAPI
-	region            *CloudRegion
-	displayName       *string
-	dns               *DNS
-	properties        map[string]string
-	state             *ClusterState
-	managed           *bool
-	externalID        *string
-	aws               *AWS
-	network           *Network
-	creationTimestamp *time.Time
-	cloudProvider     *CloudProvider
-	openshiftVersion  *string
-	subscription      *Subscription
-	groups            *GroupList
-	creator           *string
-	version           *Version
-	identityProviders *IdentityProviderList
-	metrics           *ClusterMetrics
+	id                  *string
+	href                *string
+	link                bool
+	name                *string
+	flavour             *Flavour
+	console             *ClusterConsole
+	multiAZ             *bool
+	nodes               *ClusterNodes
+	api                 *ClusterAPI
+	region              *CloudRegion
+	displayName         *string
+	dns                 *DNS
+	properties          map[string]string
+	state               *ClusterState
+	managed             *bool
+	externalID          *string
+	aws                 *AWS
+	network             *Network
+	creationTimestamp   *time.Time
+	expirationTimestamp *time.Time
+	cloudProvider       *CloudProvider
+	openshiftVersion    *string
+	subscription        *Subscription
+	groups              *GroupList
+	creator             *string
+	version             *Version
+	identityProviders   *IdentityProviderList
+	metrics             *ClusterMetrics
 }
 
 // Kind returns the name of the type of the object.
@@ -175,6 +176,7 @@ func (o *Cluster) Empty() bool {
 		o.aws == nil &&
 		o.network == nil &&
 		o.creationTimestamp == nil &&
+		o.expirationTimestamp == nil &&
 		o.cloudProvider == nil &&
 		o.openshiftVersion == nil &&
 		o.subscription == nil &&
@@ -562,6 +564,33 @@ func (o *Cluster) GetCreationTimestamp() (value time.Time, ok bool) {
 	ok = o != nil && o.creationTimestamp != nil
 	if ok {
 		value = *o.creationTimestamp
+	}
+	return
+}
+
+// ExpirationTimestamp returns the value of the 'expiration_timestamp' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Date and time when the cluster will be automatically deleted, using the format defined in
+// https://www.ietf.org/rfc/rfc3339.txt[RFC3339]. If no timestamp is provided, the cluster
+// will never expire.
+func (o *Cluster) ExpirationTimestamp() time.Time {
+	if o != nil && o.expirationTimestamp != nil {
+		return *o.expirationTimestamp
+	}
+	return time.Time{}
+}
+
+// GetExpirationTimestamp returns the value of the 'expiration_timestamp' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Date and time when the cluster will be automatically deleted, using the format defined in
+// https://www.ietf.org/rfc/rfc3339.txt[RFC3339]. If no timestamp is provided, the cluster
+// will never expire.
+func (o *Cluster) GetExpirationTimestamp() (value time.Time, ok bool) {
+	ok = o != nil && o.expirationTimestamp != nil
+	if ok {
+		value = *o.expirationTimestamp
 	}
 	return
 }


### PR DESCRIPTION
This patch adds support for the new `expiration_timestamp` column of the
cluster type.