### PR TITLE
Release 0.1.18

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the UHC API
 SDK.
 
+== 0.1.18 Jun 21 2019
+
+- Added support for the `expiration_timestamp` attribute of the `Cluster` type.
+
 == 0.1.17 Jun 20 2019
 
 - Added support for the `name` attribute of the `Dashboard` type.

--- a/pkg/client/version.go
+++ b/pkg/client/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package client
 
-const Version = "0.1.17"
+const Version = "0.1.18"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Added support for the `expiration_timestamp` attribute of the `Cluster` type.