### PR TITLE
Remove 'admin' field from debug output of ClusterCredentials

### DIFF
--- a/pkg/client/dump.go
+++ b/pkg/client/dump.go
@@ -35,6 +35,7 @@ const (
 // redactFields are removed from log output when dumped.
 var redactFields = []string{
 	"access_token",
+	"admin",
 	"id_token",
 	"refresh_token",
 	"password",


### PR DESCRIPTION
Currently the admin username and password are appearing in debug output of the client. This PR removes the `admin` field to hide that information.