### PR TITLE
Release 0.1.20

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the UHC API
 SDK.
 
+== 0.1.20 Jun 26 2019
+
+- Switch from `developers.redhat.com` to `sso.redhat.com`.
+
 == 0.1.19 Jun 25 2019
 
 - Added `GetMethod` and `GetPath` methods to HTTP requests.

--- a/pkg/client/version.go
+++ b/pkg/client/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package client
 
-const Version = "0.1.19"
+const Version = "0.1.20"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Switch from `developers.redhat.com` to `sso.redhat.com`.