### PR TITLE
Don't warn about issuer URL when no token is provided

### DIFF
--- a/pkg/client/connection.go
+++ b/pkg/client/connection.go
@@ -412,7 +412,7 @@ func (b *ConnectionBuilder) BuildContext(ctx context.Context) (connection *Conne
 	}
 	if issuerURL != nil {
 		logger.Debug(ctx, "Token issuer is '%s'", issuerURL)
-	} else {
+	} else if accessToken != nil || refreshToken != nil {
 		logger.Warn(ctx, "Can't extract issuer URL from tokens")
 	}
 


### PR DESCRIPTION
Currently the SDK generates a warning when it can't find the issuer of
tokens, even when there are no tokens. This patch changes it so that the
warning will only be generated when there is at least one token.