### PR TITLE
Release 0.1.22

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,12 @@
 This document describes the relevant changes between releases of the UHC API
 SDK.
 
+== 0.1.22 Jun 27 2019
+
+- Don't send warnings about toke issuer when no tokens are used.
+
+- Fix the names of the methods used to set the V values of the `glog` logger.
+
 == 0.1.21 Jun 26 2019
 
 - Added methods to get connection attributes like token URL, client identifier,

--- a/pkg/client/version.go
+++ b/pkg/client/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package client
 
-const Version = "0.1.21"
+const Version = "0.1.22"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Don't send warnings about toke issuer when no tokens are used.

- Fix the names of the methods used to set the V values of the `glog` logger.