### PR TITLE
Release 0.1.23

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the UHC API
 SDK.
 
+== 0.1.13 Jun 27 2019
+
+- Don't show cluster admin credentials in the debug log.
+
 == 0.1.22 Jun 27 2019
 
 - Don't send warnings about toke issuer when no tokens are used.

--- a/pkg/client/version.go
+++ b/pkg/client/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package client
 
-const Version = "0.1.22"
+const Version = "0.1.23"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Don't show cluster admin credentials in the debug log.