### PR TITLE
Release 0.1.24

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,7 +3,12 @@
 This document describes the relevant changes between releases of the UHC API
 SDK.
 
-== 0.1.13 Jun 27 2019
+== 0.1.24 Jun 28 2019
+
+- Automatically select the deprecated _OpenID_ server when authenticating with
+  user name and password.
+
+== 0.1.23 Jun 27 2019
 
 - Don't show cluster admin credentials in the debug log.
 

--- a/pkg/client/version.go
+++ b/pkg/client/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package client
 
-const Version = "0.1.23"
+const Version = "0.1.24"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Automatically select the deprecated _OpenID_ server when authenticating with
  user name and password.