### PR TITLE
Change the location of the code generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,8 @@ generate:
 		pkg/client/clustersmgmt \
 		pkg/client/errors \
 		pkg/client/helpers
-	uhc-metamodel-tool generate \
-		--model=/files/go/src/github.com/openshift-online/uhc-api-model/model \
+	ocm-metamodel-tool generate \
+		--model=/files/go/src/gitlab.cee.redhat.com/service/ocm-api-model/model \
 		--base=github.com/openshift-online/uhc-sdk-go/pkg/client \
 		--output=pkg/client
 


### PR DESCRIPTION
This patch adjusts the _Makefile_ to use the new name and location of
the model and metamodel.