### PR TITLE
Use `ocm-metamodel-tool`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ generate:
 		pkg/client/clustersmgmt \
 		pkg/client/errors \
 		pkg/client/helpers
-	uhc-metamodel-tool generate \
+	ocm-metamodel-tool generate \
 		--model=/files/go/src/gitlab.cee.redhat.com/service/ocm-api-model/model \
 		--base=github.com/openshift-online/uhc-sdk-go/pkg/client \
 		--output=pkg/client


### PR DESCRIPTION
The took that generates the code has been renamed to
`ocm-metamodel-tool`. This patch updates the _Makefile_ accordingly.