### PR TITLE
Release 0.1.25

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,12 @@
 This document describes the relevant changes between releases of the UHC API
 SDK.
 
+== 0.1.25 Aug 11 2019
+
+- Add support for quota summary.
+
+- Fix the data type of the cluster registration expiration date.
+
 == 0.1.24 Jun 28 2019
 
 - Automatically select the deprecated _OpenID_ server when authenticating with

--- a/pkg/client/version.go
+++ b/pkg/client/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package client
 
-const Version = "0.1.24"
+const Version = "0.1.25"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Add support for quota summary.

- Fix the data type of the cluster registration expiration date.