### PR TITLE
Add support for compute nodes metrics

### DIFF
--- a/pkg/client/clustersmgmt/v1/cluster_metrics_builder.go
+++ b/pkg/client/clustersmgmt/v1/cluster_metrics_builder.go
@@ -23,10 +23,12 @@ package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
 //
 // Cluster metrics received via telemetry.
 type ClusterMetricsBuilder struct {
-	cpu     *ClusterMetricBuilder
-	memory  *ClusterMetricBuilder
-	storage *ClusterMetricBuilder
-	nodes   *ClusterNodesBuilder
+	cpu                *ClusterMetricBuilder
+	memory             *ClusterMetricBuilder
+	storage            *ClusterMetricBuilder
+	computeNodesCPU    *ClusterMetricBuilder
+	computeNodesMemory *ClusterMetricBuilder
+	nodes              *ClusterNodesBuilder
 }
 
 // NewClusterMetrics creates a new builder of 'cluster_metrics' objects.
@@ -64,6 +66,26 @@ func (b *ClusterMetricsBuilder) Storage(value *ClusterMetricBuilder) *ClusterMet
 	return b
 }
 
+// ComputeNodesCPU sets the value of the 'compute_nodes_CPU' attribute
+// to the given value.
+//
+// Metric describing the total and used amount of some resource (like RAM, CPU and storage) in
+// a cluster.
+func (b *ClusterMetricsBuilder) ComputeNodesCPU(value *ClusterMetricBuilder) *ClusterMetricsBuilder {
+	b.computeNodesCPU = value
+	return b
+}
+
+// ComputeNodesMemory sets the value of the 'compute_nodes_memory' attribute
+// to the given value.
+//
+// Metric describing the total and used amount of some resource (like RAM, CPU and storage) in
+// a cluster.
+func (b *ClusterMetricsBuilder) ComputeNodesMemory(value *ClusterMetricBuilder) *ClusterMetricsBuilder {
+	b.computeNodesMemory = value
+	return b
+}
+
 // Nodes sets the value of the 'nodes' attribute
 // to the given value.
 //
@@ -90,6 +112,18 @@ func (b *ClusterMetricsBuilder) Build() (object *ClusterMetrics, err error) {
 	}
 	if b.storage != nil {
 		object.storage, err = b.storage.Build()
+		if err != nil {
+			return
+		}
+	}
+	if b.computeNodesCPU != nil {
+		object.computeNodesCPU, err = b.computeNodesCPU.Build()
+		if err != nil {
+			return
+		}
+	}
+	if b.computeNodesMemory != nil {
+		object.computeNodesMemory, err = b.computeNodesMemory.Build()
 		if err != nil {
 			return
 		}

--- a/pkg/client/clustersmgmt/v1/cluster_metrics_reader.go
+++ b/pkg/client/clustersmgmt/v1/cluster_metrics_reader.go
@@ -26,10 +26,12 @@ import (
 // clusterMetricsData is the data structure used internally to marshal and unmarshal
 // objects of type 'cluster_metrics'.
 type clusterMetricsData struct {
-	CPU     *clusterMetricData "json:\"cpu,omitempty\""
-	Memory  *clusterMetricData "json:\"memory,omitempty\""
-	Storage *clusterMetricData "json:\"storage,omitempty\""
-	Nodes   *clusterNodesData  "json:\"nodes,omitempty\""
+	CPU                *clusterMetricData "json:\"cpu,omitempty\""
+	Memory             *clusterMetricData "json:\"memory,omitempty\""
+	Storage            *clusterMetricData "json:\"storage,omitempty\""
+	ComputeNodesCPU    *clusterMetricData "json:\"compute_nodes_cpu,omitempty\""
+	ComputeNodesMemory *clusterMetricData "json:\"compute_nodes_memory,omitempty\""
+	Nodes              *clusterNodesData  "json:\"nodes,omitempty\""
 }
 
 // MarshalClusterMetrics writes a value of the 'cluster_metrics' to the given target,
@@ -62,6 +64,14 @@ func (o *ClusterMetrics) wrap() (data *clusterMetricsData, err error) {
 		return
 	}
 	data.Storage, err = o.storage.wrap()
+	if err != nil {
+		return
+	}
+	data.ComputeNodesCPU, err = o.computeNodesCPU.wrap()
+	if err != nil {
+		return
+	}
+	data.ComputeNodesMemory, err = o.computeNodesMemory.wrap()
 	if err != nil {
 		return
 	}
@@ -104,6 +114,14 @@ func (d *clusterMetricsData) unwrap() (object *ClusterMetrics, err error) {
 		return
 	}
 	object.storage, err = d.Storage.unwrap()
+	if err != nil {
+		return
+	}
+	object.computeNodesCPU, err = d.ComputeNodesCPU.unwrap()
+	if err != nil {
+		return
+	}
+	object.computeNodesMemory, err = d.ComputeNodesMemory.unwrap()
 	if err != nil {
 		return
 	}

--- a/pkg/client/clustersmgmt/v1/cluster_metrics_type.go
+++ b/pkg/client/clustersmgmt/v1/cluster_metrics_type.go
@@ -23,10 +23,12 @@ package v1 // github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1
 //
 // Cluster metrics received via telemetry.
 type ClusterMetrics struct {
-	cpu     *ClusterMetric
-	memory  *ClusterMetric
-	storage *ClusterMetric
-	nodes   *ClusterNodes
+	cpu                *ClusterMetric
+	memory             *ClusterMetric
+	storage            *ClusterMetric
+	computeNodesCPU    *ClusterMetric
+	computeNodesMemory *ClusterMetric
+	nodes              *ClusterNodes
 }
 
 // Empty returns true if the object is empty, i.e. no attribute has a value.
@@ -34,6 +36,8 @@ func (o *ClusterMetrics) Empty() bool {
 	return o == nil || (o.cpu == nil &&
 		o.memory == nil &&
 		o.storage == nil &&
+		o.computeNodesCPU == nil &&
+		o.computeNodesMemory == nil &&
 		o.nodes == nil &&
 		true)
 }
@@ -107,6 +111,52 @@ func (o *ClusterMetrics) GetStorage() (value *ClusterMetric, ok bool) {
 	ok = o != nil && o.storage != nil
 	if ok {
 		value = o.storage
+	}
+	return
+}
+
+// ComputeNodesCPU returns the value of the 'compute_nodes_CPU' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The amount of CPU provisioned and used in the cluster by compute nodes.
+func (o *ClusterMetrics) ComputeNodesCPU() *ClusterMetric {
+	if o == nil {
+		return nil
+	}
+	return o.computeNodesCPU
+}
+
+// GetComputeNodesCPU returns the value of the 'compute_nodes_CPU' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The amount of CPU provisioned and used in the cluster by compute nodes.
+func (o *ClusterMetrics) GetComputeNodesCPU() (value *ClusterMetric, ok bool) {
+	ok = o != nil && o.computeNodesCPU != nil
+	if ok {
+		value = o.computeNodesCPU
+	}
+	return
+}
+
+// ComputeNodesMemory returns the value of the 'compute_nodes_memory' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The amount of memory provisioned and used in the cluster by compute nodes.
+func (o *ClusterMetrics) ComputeNodesMemory() *ClusterMetric {
+	if o == nil {
+		return nil
+	}
+	return o.computeNodesMemory
+}
+
+// GetComputeNodesMemory returns the value of the 'compute_nodes_memory' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The amount of memory provisioned and used in the cluster by compute nodes.
+func (o *ClusterMetrics) GetComputeNodesMemory() (value *ClusterMetric, ok bool) {
+	ok = o != nil && o.computeNodesMemory != nil
+	if ok {
+		value = o.computeNodesMemory
 	}
 	return
 }


### PR DESCRIPTION
This patch adds support for the `compute_nodes_cpu` and
`compute_nodes_memory` metrics.