### PR TITLE
Release 0.1.26

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,10 @@
 This document describes the relevant changes between releases of the UHC API
 SDK.
 
+== 0.1.26 Aug 13 2019
+
+- Add support for the `compute_nodes_cpu` and `compute_nodes_memory` metrics.
+
 == 0.1.25 Aug 11 2019
 
 - Add support for quota summary.

--- a/pkg/client/version.go
+++ b/pkg/client/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package client
 
-const Version = "0.1.25"
+const Version = "0.1.26"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Add support for the `compute_nodes_cpu` and `compute_nodes_memory` metrics.