### PR TITLE
Release 0.1.27

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,12 @@
 This document describes the relevant changes between releases of the UHC API
 SDK.
 
+== 0.1.27 Aug 22 2019
+
+- Add generated servers.
+
+- Changes ClusterRegistration response type from long to string .
+
 == 0.1.26 Aug 13 2019
 
 - Add support for the `compute_nodes_cpu` and `compute_nodes_memory` metrics.

--- a/pkg/client/version.go
+++ b/pkg/client/version.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package client
 
-const Version = "0.1.26"
+const Version = "0.1.27"


### PR DESCRIPTION
- Add generated servers.

- Changes ClusterRegistration response type from long to string .

cc @jhernand 