### PR TITLE
Clone model for code generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/.gopath/
+/.gobin/
 /examples/*
+/model/
 /vendor/
 !/examples/*.go

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,9 @@
 # limitations under the License.
 #
 
-# Directory containing the model:
-model:=/files/projects/ocm-api-model/model
+# Details of the model to use:
+model_version:=v0.0.1
+model_url:=https://gitlab.cee.redhat.com/service/ocm-api-model.git
 
 .PHONY: examples
 examples:
@@ -59,13 +60,26 @@ lint:
 		$(NULL)
 
 .PHONY: generate
-generate:
+generate: model
 	rm -rf \
 		accountsmgmt \
 		clustersmgmt \
 		errors \
 		helpers
 	ocm-metamodel-tool generate \
-		--model=$(model) \
+		--model=model/model \
 		--base=github.com/openshift-online/uhc-sdk-go \
 		--output=.
+
+.PHONY: model
+model:
+	[ -d "$@" ] || git clone "$(model_url)" "$@"
+	cd "$@" && git fetch origin
+	cd "$@" && git checkout -B build "$(model_version)"
+
+.PHONY: clean
+clean:
+	rm -rf \
+		.gobin \
+		model \
+		$(NULL)


### PR DESCRIPTION
Currently the code generation expectes the API model in a directory that
can be specified using the `model` variable. This patch changes the
_Makefile_ so that it clones a specific version of the model instead.