### PR TITLE
Generated servers should handle trailing slashes in routes

### DIFF
--- a/accountsmgmt/v1/access_token_server.go
+++ b/accountsmgmt/v1/access_token_server.go
@@ -91,7 +91,7 @@ func NewAccessTokenServerAdapter(server AccessTokenServer, router *mux.Router) *
 	adapter := new(AccessTokenServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.postHandler).Methods("POST")
+	adapter.router.Methods("POST").HandlerFunc(adapter.postHandler)
 	return adapter
 }
 func (a *AccessTokenServerAdapter) readAccessTokenPostServerRequest(r *http.Request) (*AccessTokenPostServerRequest, error) {

--- a/accountsmgmt/v1/account_server.go
+++ b/accountsmgmt/v1/account_server.go
@@ -176,8 +176,8 @@ func NewAccountServerAdapter(server AccountServer, router *mux.Router) *AccountS
 	adapter := new(AccountServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.getHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.updateHandler).Methods("PATCH")
+	adapter.router.Methods("GET").HandlerFunc(adapter.getHandler)
+	adapter.router.Methods("PATCH").HandlerFunc(adapter.updateHandler)
 	return adapter
 }
 func (a *AccountServerAdapter) readAccountGetServerRequest(r *http.Request) (*AccountGetServerRequest, error) {

--- a/accountsmgmt/v1/accounts_server.go
+++ b/accountsmgmt/v1/accounts_server.go
@@ -305,15 +305,15 @@ func NewAccountsServerAdapter(server AccountsServer, router *mux.Router) *Accoun
 	adapter := new(AccountsServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/{id}/").HandlerFunc(adapter.accountHandler)
-	adapter.router.HandleFunc("/", adapter.listHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.addHandler).Methods("POST")
+	adapter.router.PathPrefix("/{id}").HandlerFunc(adapter.accountHandler)
+	adapter.router.Methods("GET").HandlerFunc(adapter.listHandler)
+	adapter.router.Methods("POST").HandlerFunc(adapter.addHandler)
 	return adapter
 }
 func (a *AccountsServerAdapter) accountHandler(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	target := a.server.Account(id)
-	targetAdapter := NewAccountServerAdapter(target, a.router.PathPrefix("/{id}/").Subrouter())
+	targetAdapter := NewAccountServerAdapter(target, a.router.PathPrefix("/{id}").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/accountsmgmt/v1/cluster_authorizations_server.go
+++ b/accountsmgmt/v1/cluster_authorizations_server.go
@@ -131,7 +131,7 @@ func NewClusterAuthorizationsServerAdapter(server ClusterAuthorizationsServer, r
 	adapter := new(ClusterAuthorizationsServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.postHandler).Methods("POST")
+	adapter.router.Methods("POST").HandlerFunc(adapter.postHandler)
 	return adapter
 }
 func (a *ClusterAuthorizationsServerAdapter) readClusterAuthorizationsPostServerRequest(r *http.Request) (*ClusterAuthorizationsPostServerRequest, error) {

--- a/accountsmgmt/v1/cluster_registrations_server.go
+++ b/accountsmgmt/v1/cluster_registrations_server.go
@@ -132,7 +132,7 @@ func NewClusterRegistrationsServerAdapter(server ClusterRegistrationsServer, rou
 	adapter := new(ClusterRegistrationsServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.postHandler).Methods("POST")
+	adapter.router.Methods("POST").HandlerFunc(adapter.postHandler)
 	return adapter
 }
 func (a *ClusterRegistrationsServerAdapter) readClusterRegistrationsPostServerRequest(r *http.Request) (*ClusterRegistrationsPostServerRequest, error) {

--- a/accountsmgmt/v1/current_account_server.go
+++ b/accountsmgmt/v1/current_account_server.go
@@ -91,7 +91,7 @@ func NewCurrentAccountServerAdapter(server CurrentAccountServer, router *mux.Rou
 	adapter := new(CurrentAccountServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.getHandler).Methods("GET")
+	adapter.router.Methods("GET").HandlerFunc(adapter.getHandler)
 	return adapter
 }
 func (a *CurrentAccountServerAdapter) readCurrentAccountGetServerRequest(r *http.Request) (*CurrentAccountGetServerRequest, error) {

--- a/accountsmgmt/v1/organization_server.go
+++ b/accountsmgmt/v1/organization_server.go
@@ -188,21 +188,21 @@ func NewOrganizationServerAdapter(server OrganizationServer, router *mux.Router)
 	adapter := new(OrganizationServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/resource_quota/").HandlerFunc(adapter.resourceQuotaHandler)
-	adapter.router.PathPrefix("/quota_summary/").HandlerFunc(adapter.quotaSummaryHandler)
-	adapter.router.HandleFunc("/", adapter.getHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.updateHandler).Methods("PATCH")
+	adapter.router.PathPrefix("/resource_quota").HandlerFunc(adapter.resourceQuotaHandler)
+	adapter.router.PathPrefix("/quota_summary").HandlerFunc(adapter.quotaSummaryHandler)
+	adapter.router.Methods("GET").HandlerFunc(adapter.getHandler)
+	adapter.router.Methods("PATCH").HandlerFunc(adapter.updateHandler)
 	return adapter
 }
 func (a *OrganizationServerAdapter) resourceQuotaHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.ResourceQuota()
-	targetAdapter := NewResourceQuotasServerAdapter(target, a.router.PathPrefix("/resource_quota/").Subrouter())
+	targetAdapter := NewResourceQuotasServerAdapter(target, a.router.PathPrefix("/resource_quota").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }
 func (a *OrganizationServerAdapter) quotaSummaryHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.QuotaSummary()
-	targetAdapter := NewQuotaSummaryServerAdapter(target, a.router.PathPrefix("/quota_summary/").Subrouter())
+	targetAdapter := NewQuotaSummaryServerAdapter(target, a.router.PathPrefix("/quota_summary").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/accountsmgmt/v1/organizations_server.go
+++ b/accountsmgmt/v1/organizations_server.go
@@ -305,15 +305,15 @@ func NewOrganizationsServerAdapter(server OrganizationsServer, router *mux.Route
 	adapter := new(OrganizationsServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/{id}/").HandlerFunc(adapter.organizationHandler)
-	adapter.router.HandleFunc("/", adapter.listHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.addHandler).Methods("POST")
+	adapter.router.PathPrefix("/{id}").HandlerFunc(adapter.organizationHandler)
+	adapter.router.Methods("GET").HandlerFunc(adapter.listHandler)
+	adapter.router.Methods("POST").HandlerFunc(adapter.addHandler)
 	return adapter
 }
 func (a *OrganizationsServerAdapter) organizationHandler(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	target := a.server.Organization(id)
-	targetAdapter := NewOrganizationServerAdapter(target, a.router.PathPrefix("/{id}/").Subrouter())
+	targetAdapter := NewOrganizationServerAdapter(target, a.router.PathPrefix("/{id}").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/accountsmgmt/v1/permission_server.go
+++ b/accountsmgmt/v1/permission_server.go
@@ -114,8 +114,8 @@ func NewPermissionServerAdapter(server PermissionServer, router *mux.Router) *Pe
 	adapter := new(PermissionServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.getHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.deleteHandler).Methods("DELETE")
+	adapter.router.Methods("GET").HandlerFunc(adapter.getHandler)
+	adapter.router.Methods("DELETE").HandlerFunc(adapter.deleteHandler)
 	return adapter
 }
 func (a *PermissionServerAdapter) readPermissionGetServerRequest(r *http.Request) (*PermissionGetServerRequest, error) {

--- a/accountsmgmt/v1/permissions_server.go
+++ b/accountsmgmt/v1/permissions_server.go
@@ -305,15 +305,15 @@ func NewPermissionsServerAdapter(server PermissionsServer, router *mux.Router) *
 	adapter := new(PermissionsServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/{id}/").HandlerFunc(adapter.permissionHandler)
-	adapter.router.HandleFunc("/", adapter.listHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.addHandler).Methods("POST")
+	adapter.router.PathPrefix("/{id}").HandlerFunc(adapter.permissionHandler)
+	adapter.router.Methods("GET").HandlerFunc(adapter.listHandler)
+	adapter.router.Methods("POST").HandlerFunc(adapter.addHandler)
 	return adapter
 }
 func (a *PermissionsServerAdapter) permissionHandler(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	target := a.server.Permission(id)
-	targetAdapter := NewPermissionServerAdapter(target, a.router.PathPrefix("/{id}/").Subrouter())
+	targetAdapter := NewPermissionServerAdapter(target, a.router.PathPrefix("/{id}").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/accountsmgmt/v1/quota_summary_server.go
+++ b/accountsmgmt/v1/quota_summary_server.go
@@ -266,7 +266,7 @@ func NewQuotaSummaryServerAdapter(server QuotaSummaryServer, router *mux.Router)
 	adapter := new(QuotaSummaryServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.listHandler).Methods("GET")
+	adapter.router.Methods("GET").HandlerFunc(adapter.listHandler)
 	return adapter
 }
 func (a *QuotaSummaryServerAdapter) readQuotaSummaryListServerRequest(r *http.Request) (*QuotaSummaryListServerRequest, error) {

--- a/accountsmgmt/v1/registries_server.go
+++ b/accountsmgmt/v1/registries_server.go
@@ -220,14 +220,14 @@ func NewRegistriesServerAdapter(server RegistriesServer, router *mux.Router) *Re
 	adapter := new(RegistriesServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/{id}/").HandlerFunc(adapter.registryHandler)
-	adapter.router.HandleFunc("/", adapter.listHandler).Methods("GET")
+	adapter.router.PathPrefix("/{id}").HandlerFunc(adapter.registryHandler)
+	adapter.router.Methods("GET").HandlerFunc(adapter.listHandler)
 	return adapter
 }
 func (a *RegistriesServerAdapter) registryHandler(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	target := a.server.Registry(id)
-	targetAdapter := NewRegistryServerAdapter(target, a.router.PathPrefix("/{id}/").Subrouter())
+	targetAdapter := NewRegistryServerAdapter(target, a.router.PathPrefix("/{id}").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/accountsmgmt/v1/registry_credential_server.go
+++ b/accountsmgmt/v1/registry_credential_server.go
@@ -91,7 +91,7 @@ func NewRegistryCredentialServerAdapter(server RegistryCredentialServer, router 
 	adapter := new(RegistryCredentialServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.getHandler).Methods("GET")
+	adapter.router.Methods("GET").HandlerFunc(adapter.getHandler)
 	return adapter
 }
 func (a *RegistryCredentialServerAdapter) readRegistryCredentialGetServerRequest(r *http.Request) (*RegistryCredentialGetServerRequest, error) {

--- a/accountsmgmt/v1/registry_credentials_server.go
+++ b/accountsmgmt/v1/registry_credentials_server.go
@@ -305,15 +305,15 @@ func NewRegistryCredentialsServerAdapter(server RegistryCredentialsServer, route
 	adapter := new(RegistryCredentialsServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/{id}/").HandlerFunc(adapter.registryCredentialHandler)
-	adapter.router.HandleFunc("/", adapter.listHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.addHandler).Methods("POST")
+	adapter.router.PathPrefix("/{id}").HandlerFunc(adapter.registryCredentialHandler)
+	adapter.router.Methods("GET").HandlerFunc(adapter.listHandler)
+	adapter.router.Methods("POST").HandlerFunc(adapter.addHandler)
 	return adapter
 }
 func (a *RegistryCredentialsServerAdapter) registryCredentialHandler(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	target := a.server.RegistryCredential(id)
-	targetAdapter := NewRegistryCredentialServerAdapter(target, a.router.PathPrefix("/{id}/").Subrouter())
+	targetAdapter := NewRegistryCredentialServerAdapter(target, a.router.PathPrefix("/{id}").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/accountsmgmt/v1/registry_server.go
+++ b/accountsmgmt/v1/registry_server.go
@@ -91,7 +91,7 @@ func NewRegistryServerAdapter(server RegistryServer, router *mux.Router) *Regist
 	adapter := new(RegistryServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.getHandler).Methods("GET")
+	adapter.router.Methods("GET").HandlerFunc(adapter.getHandler)
 	return adapter
 }
 func (a *RegistryServerAdapter) readRegistryGetServerRequest(r *http.Request) (*RegistryGetServerRequest, error) {

--- a/accountsmgmt/v1/resource_quota_server.go
+++ b/accountsmgmt/v1/resource_quota_server.go
@@ -176,8 +176,8 @@ func NewResourceQuotaServerAdapter(server ResourceQuotaServer, router *mux.Route
 	adapter := new(ResourceQuotaServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.getHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.updateHandler).Methods("PATCH")
+	adapter.router.Methods("GET").HandlerFunc(adapter.getHandler)
+	adapter.router.Methods("PATCH").HandlerFunc(adapter.updateHandler)
 	return adapter
 }
 func (a *ResourceQuotaServerAdapter) readResourceQuotaGetServerRequest(r *http.Request) (*ResourceQuotaGetServerRequest, error) {

--- a/accountsmgmt/v1/resource_quotas_server.go
+++ b/accountsmgmt/v1/resource_quotas_server.go
@@ -305,15 +305,15 @@ func NewResourceQuotasServerAdapter(server ResourceQuotasServer, router *mux.Rou
 	adapter := new(ResourceQuotasServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/{id}/").HandlerFunc(adapter.resourceQuotaHandler)
-	adapter.router.HandleFunc("/", adapter.listHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.addHandler).Methods("POST")
+	adapter.router.PathPrefix("/{id}").HandlerFunc(adapter.resourceQuotaHandler)
+	adapter.router.Methods("GET").HandlerFunc(adapter.listHandler)
+	adapter.router.Methods("POST").HandlerFunc(adapter.addHandler)
 	return adapter
 }
 func (a *ResourceQuotasServerAdapter) resourceQuotaHandler(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	target := a.server.ResourceQuota(id)
-	targetAdapter := NewResourceQuotaServerAdapter(target, a.router.PathPrefix("/{id}/").Subrouter())
+	targetAdapter := NewResourceQuotaServerAdapter(target, a.router.PathPrefix("/{id}").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/accountsmgmt/v1/role_binding_server.go
+++ b/accountsmgmt/v1/role_binding_server.go
@@ -114,8 +114,8 @@ func NewRoleBindingServerAdapter(server RoleBindingServer, router *mux.Router) *
 	adapter := new(RoleBindingServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.getHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.deleteHandler).Methods("DELETE")
+	adapter.router.Methods("GET").HandlerFunc(adapter.getHandler)
+	adapter.router.Methods("DELETE").HandlerFunc(adapter.deleteHandler)
 	return adapter
 }
 func (a *RoleBindingServerAdapter) readRoleBindingGetServerRequest(r *http.Request) (*RoleBindingGetServerRequest, error) {

--- a/accountsmgmt/v1/role_bindings_server.go
+++ b/accountsmgmt/v1/role_bindings_server.go
@@ -305,15 +305,15 @@ func NewRoleBindingsServerAdapter(server RoleBindingsServer, router *mux.Router)
 	adapter := new(RoleBindingsServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/{id}/").HandlerFunc(adapter.roleBindingHandler)
-	adapter.router.HandleFunc("/", adapter.listHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.addHandler).Methods("POST")
+	adapter.router.PathPrefix("/{id}").HandlerFunc(adapter.roleBindingHandler)
+	adapter.router.Methods("GET").HandlerFunc(adapter.listHandler)
+	adapter.router.Methods("POST").HandlerFunc(adapter.addHandler)
 	return adapter
 }
 func (a *RoleBindingsServerAdapter) roleBindingHandler(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	target := a.server.RoleBinding(id)
-	targetAdapter := NewRoleBindingServerAdapter(target, a.router.PathPrefix("/{id}/").Subrouter())
+	targetAdapter := NewRoleBindingServerAdapter(target, a.router.PathPrefix("/{id}").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/accountsmgmt/v1/role_server.go
+++ b/accountsmgmt/v1/role_server.go
@@ -199,9 +199,9 @@ func NewRoleServerAdapter(server RoleServer, router *mux.Router) *RoleServerAdap
 	adapter := new(RoleServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.getHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.updateHandler).Methods("PATCH")
-	adapter.router.HandleFunc("/", adapter.deleteHandler).Methods("DELETE")
+	adapter.router.Methods("GET").HandlerFunc(adapter.getHandler)
+	adapter.router.Methods("PATCH").HandlerFunc(adapter.updateHandler)
+	adapter.router.Methods("DELETE").HandlerFunc(adapter.deleteHandler)
 	return adapter
 }
 func (a *RoleServerAdapter) readRoleGetServerRequest(r *http.Request) (*RoleGetServerRequest, error) {

--- a/accountsmgmt/v1/roles_server.go
+++ b/accountsmgmt/v1/roles_server.go
@@ -305,15 +305,15 @@ func NewRolesServerAdapter(server RolesServer, router *mux.Router) *RolesServerA
 	adapter := new(RolesServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/{id}/").HandlerFunc(adapter.roleHandler)
-	adapter.router.HandleFunc("/", adapter.listHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.addHandler).Methods("POST")
+	adapter.router.PathPrefix("/{id}").HandlerFunc(adapter.roleHandler)
+	adapter.router.Methods("GET").HandlerFunc(adapter.listHandler)
+	adapter.router.Methods("POST").HandlerFunc(adapter.addHandler)
 	return adapter
 }
 func (a *RolesServerAdapter) roleHandler(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	target := a.server.Role(id)
-	targetAdapter := NewRoleServerAdapter(target, a.router.PathPrefix("/{id}/").Subrouter())
+	targetAdapter := NewRoleServerAdapter(target, a.router.PathPrefix("/{id}").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/accountsmgmt/v1/root_server.go
+++ b/accountsmgmt/v1/root_server.go
@@ -105,89 +105,89 @@ func NewRootServerAdapter(server RootServer, router *mux.Router) *RootServerAdap
 	adapter := new(RootServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/accounts/").HandlerFunc(adapter.accountsHandler)
-	adapter.router.PathPrefix("/current_account/").HandlerFunc(adapter.currentAccountHandler)
-	adapter.router.PathPrefix("/organizations/").HandlerFunc(adapter.organizationsHandler)
-	adapter.router.PathPrefix("/access_token/").HandlerFunc(adapter.accessTokenHandler)
-	adapter.router.PathPrefix("/permissions/").HandlerFunc(adapter.permissionsHandler)
-	adapter.router.PathPrefix("/registries/").HandlerFunc(adapter.registriesHandler)
-	adapter.router.PathPrefix("/registry_credentials/").HandlerFunc(adapter.registryCredentialsHandler)
-	adapter.router.PathPrefix("/cluster_authorizations/").HandlerFunc(adapter.clusterAuthorizationsHandler)
-	adapter.router.PathPrefix("/cluster_registrations/").HandlerFunc(adapter.clusterRegistrationsHandler)
-	adapter.router.PathPrefix("/roles/").HandlerFunc(adapter.rolesHandler)
-	adapter.router.PathPrefix("/role_bindings/").HandlerFunc(adapter.roleBindingsHandler)
-	adapter.router.PathPrefix("/subscriptions/").HandlerFunc(adapter.subscriptionsHandler)
+	adapter.router.PathPrefix("/accounts").HandlerFunc(adapter.accountsHandler)
+	adapter.router.PathPrefix("/current_account").HandlerFunc(adapter.currentAccountHandler)
+	adapter.router.PathPrefix("/organizations").HandlerFunc(adapter.organizationsHandler)
+	adapter.router.PathPrefix("/access_token").HandlerFunc(adapter.accessTokenHandler)
+	adapter.router.PathPrefix("/permissions").HandlerFunc(adapter.permissionsHandler)
+	adapter.router.PathPrefix("/registries").HandlerFunc(adapter.registriesHandler)
+	adapter.router.PathPrefix("/registry_credentials").HandlerFunc(adapter.registryCredentialsHandler)
+	adapter.router.PathPrefix("/cluster_authorizations").HandlerFunc(adapter.clusterAuthorizationsHandler)
+	adapter.router.PathPrefix("/cluster_registrations").HandlerFunc(adapter.clusterRegistrationsHandler)
+	adapter.router.PathPrefix("/roles").HandlerFunc(adapter.rolesHandler)
+	adapter.router.PathPrefix("/role_bindings").HandlerFunc(adapter.roleBindingsHandler)
+	adapter.router.PathPrefix("/subscriptions").HandlerFunc(adapter.subscriptionsHandler)
 	return adapter
 }
 func (a *RootServerAdapter) accountsHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.Accounts()
-	targetAdapter := NewAccountsServerAdapter(target, a.router.PathPrefix("/accounts/").Subrouter())
+	targetAdapter := NewAccountsServerAdapter(target, a.router.PathPrefix("/accounts").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }
 func (a *RootServerAdapter) currentAccountHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.CurrentAccount()
-	targetAdapter := NewCurrentAccountServerAdapter(target, a.router.PathPrefix("/current_account/").Subrouter())
+	targetAdapter := NewCurrentAccountServerAdapter(target, a.router.PathPrefix("/current_account").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }
 func (a *RootServerAdapter) organizationsHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.Organizations()
-	targetAdapter := NewOrganizationsServerAdapter(target, a.router.PathPrefix("/organizations/").Subrouter())
+	targetAdapter := NewOrganizationsServerAdapter(target, a.router.PathPrefix("/organizations").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }
 func (a *RootServerAdapter) accessTokenHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.AccessToken()
-	targetAdapter := NewAccessTokenServerAdapter(target, a.router.PathPrefix("/access_token/").Subrouter())
+	targetAdapter := NewAccessTokenServerAdapter(target, a.router.PathPrefix("/access_token").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }
 func (a *RootServerAdapter) permissionsHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.Permissions()
-	targetAdapter := NewPermissionsServerAdapter(target, a.router.PathPrefix("/permissions/").Subrouter())
+	targetAdapter := NewPermissionsServerAdapter(target, a.router.PathPrefix("/permissions").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }
 func (a *RootServerAdapter) registriesHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.Registries()
-	targetAdapter := NewRegistriesServerAdapter(target, a.router.PathPrefix("/registries/").Subrouter())
+	targetAdapter := NewRegistriesServerAdapter(target, a.router.PathPrefix("/registries").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }
 func (a *RootServerAdapter) registryCredentialsHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.RegistryCredentials()
-	targetAdapter := NewRegistryCredentialsServerAdapter(target, a.router.PathPrefix("/registry_credentials/").Subrouter())
+	targetAdapter := NewRegistryCredentialsServerAdapter(target, a.router.PathPrefix("/registry_credentials").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }
 func (a *RootServerAdapter) clusterAuthorizationsHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.ClusterAuthorizations()
-	targetAdapter := NewClusterAuthorizationsServerAdapter(target, a.router.PathPrefix("/cluster_authorizations/").Subrouter())
+	targetAdapter := NewClusterAuthorizationsServerAdapter(target, a.router.PathPrefix("/cluster_authorizations").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }
 func (a *RootServerAdapter) clusterRegistrationsHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.ClusterRegistrations()
-	targetAdapter := NewClusterRegistrationsServerAdapter(target, a.router.PathPrefix("/cluster_registrations/").Subrouter())
+	targetAdapter := NewClusterRegistrationsServerAdapter(target, a.router.PathPrefix("/cluster_registrations").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }
 func (a *RootServerAdapter) rolesHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.Roles()
-	targetAdapter := NewRolesServerAdapter(target, a.router.PathPrefix("/roles/").Subrouter())
+	targetAdapter := NewRolesServerAdapter(target, a.router.PathPrefix("/roles").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }
 func (a *RootServerAdapter) roleBindingsHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.RoleBindings()
-	targetAdapter := NewRoleBindingsServerAdapter(target, a.router.PathPrefix("/role_bindings/").Subrouter())
+	targetAdapter := NewRoleBindingsServerAdapter(target, a.router.PathPrefix("/role_bindings").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }
 func (a *RootServerAdapter) subscriptionsHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.Subscriptions()
-	targetAdapter := NewSubscriptionsServerAdapter(target, a.router.PathPrefix("/subscriptions/").Subrouter())
+	targetAdapter := NewSubscriptionsServerAdapter(target, a.router.PathPrefix("/subscriptions").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/accountsmgmt/v1/subscription_server.go
+++ b/accountsmgmt/v1/subscription_server.go
@@ -114,8 +114,8 @@ func NewSubscriptionServerAdapter(server SubscriptionServer, router *mux.Router)
 	adapter := new(SubscriptionServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.getHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.deleteHandler).Methods("DELETE")
+	adapter.router.Methods("GET").HandlerFunc(adapter.getHandler)
+	adapter.router.Methods("DELETE").HandlerFunc(adapter.deleteHandler)
 	return adapter
 }
 func (a *SubscriptionServerAdapter) readSubscriptionGetServerRequest(r *http.Request) (*SubscriptionGetServerRequest, error) {

--- a/accountsmgmt/v1/subscriptions_server.go
+++ b/accountsmgmt/v1/subscriptions_server.go
@@ -220,14 +220,14 @@ func NewSubscriptionsServerAdapter(server SubscriptionsServer, router *mux.Route
 	adapter := new(SubscriptionsServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/{id}/").HandlerFunc(adapter.subscriptionHandler)
-	adapter.router.HandleFunc("/", adapter.listHandler).Methods("GET")
+	adapter.router.PathPrefix("/{id}").HandlerFunc(adapter.subscriptionHandler)
+	adapter.router.Methods("GET").HandlerFunc(adapter.listHandler)
 	return adapter
 }
 func (a *SubscriptionsServerAdapter) subscriptionHandler(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	target := a.server.Subscription(id)
-	targetAdapter := NewSubscriptionServerAdapter(target, a.router.PathPrefix("/{id}/").Subrouter())
+	targetAdapter := NewSubscriptionServerAdapter(target, a.router.PathPrefix("/{id}").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/clustersmgmt/v1/cluster_server.go
+++ b/clustersmgmt/v1/cluster_server.go
@@ -224,43 +224,43 @@ func NewClusterServerAdapter(server ClusterServer, router *mux.Router) *ClusterS
 	adapter := new(ClusterServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/status/").HandlerFunc(adapter.statusHandler)
-	adapter.router.PathPrefix("/credentials/").HandlerFunc(adapter.credentialsHandler)
-	adapter.router.PathPrefix("/logs/").HandlerFunc(adapter.logsHandler)
-	adapter.router.PathPrefix("/groups/").HandlerFunc(adapter.groupsHandler)
-	adapter.router.PathPrefix("/identity_providers/").HandlerFunc(adapter.identityProvidersHandler)
-	adapter.router.HandleFunc("/", adapter.getHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.updateHandler).Methods("PATCH")
-	adapter.router.HandleFunc("/", adapter.deleteHandler).Methods("DELETE")
+	adapter.router.PathPrefix("/status").HandlerFunc(adapter.statusHandler)
+	adapter.router.PathPrefix("/credentials").HandlerFunc(adapter.credentialsHandler)
+	adapter.router.PathPrefix("/logs").HandlerFunc(adapter.logsHandler)
+	adapter.router.PathPrefix("/groups").HandlerFunc(adapter.groupsHandler)
+	adapter.router.PathPrefix("/identity_providers").HandlerFunc(adapter.identityProvidersHandler)
+	adapter.router.Methods("GET").HandlerFunc(adapter.getHandler)
+	adapter.router.Methods("PATCH").HandlerFunc(adapter.updateHandler)
+	adapter.router.Methods("DELETE").HandlerFunc(adapter.deleteHandler)
 	return adapter
 }
 func (a *ClusterServerAdapter) statusHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.Status()
-	targetAdapter := NewClusterStatusServerAdapter(target, a.router.PathPrefix("/status/").Subrouter())
+	targetAdapter := NewClusterStatusServerAdapter(target, a.router.PathPrefix("/status").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }
 func (a *ClusterServerAdapter) credentialsHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.Credentials()
-	targetAdapter := NewCredentialsServerAdapter(target, a.router.PathPrefix("/credentials/").Subrouter())
+	targetAdapter := NewCredentialsServerAdapter(target, a.router.PathPrefix("/credentials").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }
 func (a *ClusterServerAdapter) logsHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.Logs()
-	targetAdapter := NewLogsServerAdapter(target, a.router.PathPrefix("/logs/").Subrouter())
+	targetAdapter := NewLogsServerAdapter(target, a.router.PathPrefix("/logs").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }
 func (a *ClusterServerAdapter) groupsHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.Groups()
-	targetAdapter := NewGroupsServerAdapter(target, a.router.PathPrefix("/groups/").Subrouter())
+	targetAdapter := NewGroupsServerAdapter(target, a.router.PathPrefix("/groups").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }
 func (a *ClusterServerAdapter) identityProvidersHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.IdentityProviders()
-	targetAdapter := NewIdentityProvidersServerAdapter(target, a.router.PathPrefix("/identity_providers/").Subrouter())
+	targetAdapter := NewIdentityProvidersServerAdapter(target, a.router.PathPrefix("/identity_providers").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/clustersmgmt/v1/cluster_status_server.go
+++ b/clustersmgmt/v1/cluster_status_server.go
@@ -91,7 +91,7 @@ func NewClusterStatusServerAdapter(server ClusterStatusServer, router *mux.Route
 	adapter := new(ClusterStatusServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.getHandler).Methods("GET")
+	adapter.router.Methods("GET").HandlerFunc(adapter.getHandler)
 	return adapter
 }
 func (a *ClusterStatusServerAdapter) readClusterStatusGetServerRequest(r *http.Request) (*ClusterStatusGetServerRequest, error) {

--- a/clustersmgmt/v1/clusters_server.go
+++ b/clustersmgmt/v1/clusters_server.go
@@ -358,15 +358,15 @@ func NewClustersServerAdapter(server ClustersServer, router *mux.Router) *Cluste
 	adapter := new(ClustersServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/{id}/").HandlerFunc(adapter.clusterHandler)
-	adapter.router.HandleFunc("/", adapter.listHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.addHandler).Methods("POST")
+	adapter.router.PathPrefix("/{id}").HandlerFunc(adapter.clusterHandler)
+	adapter.router.Methods("GET").HandlerFunc(adapter.listHandler)
+	adapter.router.Methods("POST").HandlerFunc(adapter.addHandler)
 	return adapter
 }
 func (a *ClustersServerAdapter) clusterHandler(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	target := a.server.Cluster(id)
-	targetAdapter := NewClusterServerAdapter(target, a.router.PathPrefix("/{id}/").Subrouter())
+	targetAdapter := NewClusterServerAdapter(target, a.router.PathPrefix("/{id}").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/clustersmgmt/v1/credentials_server.go
+++ b/clustersmgmt/v1/credentials_server.go
@@ -91,7 +91,7 @@ func NewCredentialsServerAdapter(server CredentialsServer, router *mux.Router) *
 	adapter := new(CredentialsServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.getHandler).Methods("GET")
+	adapter.router.Methods("GET").HandlerFunc(adapter.getHandler)
 	return adapter
 }
 func (a *CredentialsServerAdapter) readCredentialsGetServerRequest(r *http.Request) (*CredentialsGetServerRequest, error) {

--- a/clustersmgmt/v1/dashboard_server.go
+++ b/clustersmgmt/v1/dashboard_server.go
@@ -91,7 +91,7 @@ func NewDashboardServerAdapter(server DashboardServer, router *mux.Router) *Dash
 	adapter := new(DashboardServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.getHandler).Methods("GET")
+	adapter.router.Methods("GET").HandlerFunc(adapter.getHandler)
 	return adapter
 }
 func (a *DashboardServerAdapter) readDashboardGetServerRequest(r *http.Request) (*DashboardGetServerRequest, error) {

--- a/clustersmgmt/v1/dashboards_server.go
+++ b/clustersmgmt/v1/dashboards_server.go
@@ -273,14 +273,14 @@ func NewDashboardsServerAdapter(server DashboardsServer, router *mux.Router) *Da
 	adapter := new(DashboardsServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/{id}/").HandlerFunc(adapter.dashboardHandler)
-	adapter.router.HandleFunc("/", adapter.listHandler).Methods("GET")
+	adapter.router.PathPrefix("/{id}").HandlerFunc(adapter.dashboardHandler)
+	adapter.router.Methods("GET").HandlerFunc(adapter.listHandler)
 	return adapter
 }
 func (a *DashboardsServerAdapter) dashboardHandler(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	target := a.server.Dashboard(id)
-	targetAdapter := NewDashboardServerAdapter(target, a.router.PathPrefix("/{id}/").Subrouter())
+	targetAdapter := NewDashboardServerAdapter(target, a.router.PathPrefix("/{id}").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/clustersmgmt/v1/flavour_server.go
+++ b/clustersmgmt/v1/flavour_server.go
@@ -91,7 +91,7 @@ func NewFlavourServerAdapter(server FlavourServer, router *mux.Router) *FlavourS
 	adapter := new(FlavourServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.getHandler).Methods("GET")
+	adapter.router.Methods("GET").HandlerFunc(adapter.getHandler)
 	return adapter
 }
 func (a *FlavourServerAdapter) readFlavourGetServerRequest(r *http.Request) (*FlavourGetServerRequest, error) {

--- a/clustersmgmt/v1/flavours_server.go
+++ b/clustersmgmt/v1/flavours_server.go
@@ -354,15 +354,15 @@ func NewFlavoursServerAdapter(server FlavoursServer, router *mux.Router) *Flavou
 	adapter := new(FlavoursServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/{id}/").HandlerFunc(adapter.flavourHandler)
-	adapter.router.HandleFunc("/", adapter.listHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.addHandler).Methods("POST")
+	adapter.router.PathPrefix("/{id}").HandlerFunc(adapter.flavourHandler)
+	adapter.router.Methods("GET").HandlerFunc(adapter.listHandler)
+	adapter.router.Methods("POST").HandlerFunc(adapter.addHandler)
 	return adapter
 }
 func (a *FlavoursServerAdapter) flavourHandler(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	target := a.server.Flavour(id)
-	targetAdapter := NewFlavourServerAdapter(target, a.router.PathPrefix("/{id}/").Subrouter())
+	targetAdapter := NewFlavourServerAdapter(target, a.router.PathPrefix("/{id}").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/clustersmgmt/v1/group_server.go
+++ b/clustersmgmt/v1/group_server.go
@@ -96,13 +96,13 @@ func NewGroupServerAdapter(server GroupServer, router *mux.Router) *GroupServerA
 	adapter := new(GroupServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/users/").HandlerFunc(adapter.usersHandler)
-	adapter.router.HandleFunc("/", adapter.getHandler).Methods("GET")
+	adapter.router.PathPrefix("/users").HandlerFunc(adapter.usersHandler)
+	adapter.router.Methods("GET").HandlerFunc(adapter.getHandler)
 	return adapter
 }
 func (a *GroupServerAdapter) usersHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.Users()
-	targetAdapter := NewUsersServerAdapter(target, a.router.PathPrefix("/users/").Subrouter())
+	targetAdapter := NewUsersServerAdapter(target, a.router.PathPrefix("/users").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/clustersmgmt/v1/groups_server.go
+++ b/clustersmgmt/v1/groups_server.go
@@ -136,14 +136,14 @@ func NewGroupsServerAdapter(server GroupsServer, router *mux.Router) *GroupsServ
 	adapter := new(GroupsServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/{id}/").HandlerFunc(adapter.groupHandler)
-	adapter.router.HandleFunc("/", adapter.listHandler).Methods("GET")
+	adapter.router.PathPrefix("/{id}").HandlerFunc(adapter.groupHandler)
+	adapter.router.Methods("GET").HandlerFunc(adapter.listHandler)
 	return adapter
 }
 func (a *GroupsServerAdapter) groupHandler(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	target := a.server.Group(id)
-	targetAdapter := NewGroupServerAdapter(target, a.router.PathPrefix("/{id}/").Subrouter())
+	targetAdapter := NewGroupServerAdapter(target, a.router.PathPrefix("/{id}").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/clustersmgmt/v1/identity_provider_server.go
+++ b/clustersmgmt/v1/identity_provider_server.go
@@ -114,8 +114,8 @@ func NewIdentityProviderServerAdapter(server IdentityProviderServer, router *mux
 	adapter := new(IdentityProviderServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.getHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.deleteHandler).Methods("DELETE")
+	adapter.router.Methods("GET").HandlerFunc(adapter.getHandler)
+	adapter.router.Methods("DELETE").HandlerFunc(adapter.deleteHandler)
 	return adapter
 }
 func (a *IdentityProviderServerAdapter) readIdentityProviderGetServerRequest(r *http.Request) (*IdentityProviderGetServerRequest, error) {

--- a/clustersmgmt/v1/identity_providers_server.go
+++ b/clustersmgmt/v1/identity_providers_server.go
@@ -221,15 +221,15 @@ func NewIdentityProvidersServerAdapter(server IdentityProvidersServer, router *m
 	adapter := new(IdentityProvidersServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/{id}/").HandlerFunc(adapter.identityProviderHandler)
-	adapter.router.HandleFunc("/", adapter.listHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.addHandler).Methods("POST")
+	adapter.router.PathPrefix("/{id}").HandlerFunc(adapter.identityProviderHandler)
+	adapter.router.Methods("GET").HandlerFunc(adapter.listHandler)
+	adapter.router.Methods("POST").HandlerFunc(adapter.addHandler)
 	return adapter
 }
 func (a *IdentityProvidersServerAdapter) identityProviderHandler(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	target := a.server.IdentityProvider(id)
-	targetAdapter := NewIdentityProviderServerAdapter(target, a.router.PathPrefix("/{id}/").Subrouter())
+	targetAdapter := NewIdentityProviderServerAdapter(target, a.router.PathPrefix("/{id}").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/clustersmgmt/v1/log_server.go
+++ b/clustersmgmt/v1/log_server.go
@@ -91,7 +91,7 @@ func NewLogServerAdapter(server LogServer, router *mux.Router) *LogServerAdapter
 	adapter := new(LogServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.getHandler).Methods("GET")
+	adapter.router.Methods("GET").HandlerFunc(adapter.getHandler)
 	return adapter
 }
 func (a *LogServerAdapter) readLogGetServerRequest(r *http.Request) (*LogGetServerRequest, error) {

--- a/clustersmgmt/v1/logs_server.go
+++ b/clustersmgmt/v1/logs_server.go
@@ -136,14 +136,14 @@ func NewLogsServerAdapter(server LogsServer, router *mux.Router) *LogsServerAdap
 	adapter := new(LogsServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/{id}/").HandlerFunc(adapter.logHandler)
-	adapter.router.HandleFunc("/", adapter.listHandler).Methods("GET")
+	adapter.router.PathPrefix("/{id}").HandlerFunc(adapter.logHandler)
+	adapter.router.Methods("GET").HandlerFunc(adapter.listHandler)
 	return adapter
 }
 func (a *LogsServerAdapter) logHandler(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	target := a.server.Log(id)
-	targetAdapter := NewLogServerAdapter(target, a.router.PathPrefix("/{id}/").Subrouter())
+	targetAdapter := NewLogServerAdapter(target, a.router.PathPrefix("/{id}").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/clustersmgmt/v1/root_server.go
+++ b/clustersmgmt/v1/root_server.go
@@ -60,33 +60,33 @@ func NewRootServerAdapter(server RootServer, router *mux.Router) *RootServerAdap
 	adapter := new(RootServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/clusters/").HandlerFunc(adapter.clustersHandler)
-	adapter.router.PathPrefix("/dashboards/").HandlerFunc(adapter.dashboardsHandler)
-	adapter.router.PathPrefix("/flavours/").HandlerFunc(adapter.flavoursHandler)
-	adapter.router.PathPrefix("/versions/").HandlerFunc(adapter.versionsHandler)
+	adapter.router.PathPrefix("/clusters").HandlerFunc(adapter.clustersHandler)
+	adapter.router.PathPrefix("/dashboards").HandlerFunc(adapter.dashboardsHandler)
+	adapter.router.PathPrefix("/flavours").HandlerFunc(adapter.flavoursHandler)
+	adapter.router.PathPrefix("/versions").HandlerFunc(adapter.versionsHandler)
 	return adapter
 }
 func (a *RootServerAdapter) clustersHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.Clusters()
-	targetAdapter := NewClustersServerAdapter(target, a.router.PathPrefix("/clusters/").Subrouter())
+	targetAdapter := NewClustersServerAdapter(target, a.router.PathPrefix("/clusters").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }
 func (a *RootServerAdapter) dashboardsHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.Dashboards()
-	targetAdapter := NewDashboardsServerAdapter(target, a.router.PathPrefix("/dashboards/").Subrouter())
+	targetAdapter := NewDashboardsServerAdapter(target, a.router.PathPrefix("/dashboards").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }
 func (a *RootServerAdapter) flavoursHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.Flavours()
-	targetAdapter := NewFlavoursServerAdapter(target, a.router.PathPrefix("/flavours/").Subrouter())
+	targetAdapter := NewFlavoursServerAdapter(target, a.router.PathPrefix("/flavours").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }
 func (a *RootServerAdapter) versionsHandler(w http.ResponseWriter, r *http.Request) {
 	target := a.server.Versions()
-	targetAdapter := NewVersionsServerAdapter(target, a.router.PathPrefix("/versions/").Subrouter())
+	targetAdapter := NewVersionsServerAdapter(target, a.router.PathPrefix("/versions").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/clustersmgmt/v1/user_server.go
+++ b/clustersmgmt/v1/user_server.go
@@ -114,8 +114,8 @@ func NewUserServerAdapter(server UserServer, router *mux.Router) *UserServerAdap
 	adapter := new(UserServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.getHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.deleteHandler).Methods("DELETE")
+	adapter.router.Methods("GET").HandlerFunc(adapter.getHandler)
+	adapter.router.Methods("DELETE").HandlerFunc(adapter.deleteHandler)
 	return adapter
 }
 func (a *UserServerAdapter) readUserGetServerRequest(r *http.Request) (*UserGetServerRequest, error) {

--- a/clustersmgmt/v1/users_server.go
+++ b/clustersmgmt/v1/users_server.go
@@ -221,15 +221,15 @@ func NewUsersServerAdapter(server UsersServer, router *mux.Router) *UsersServerA
 	adapter := new(UsersServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/{id}/").HandlerFunc(adapter.userHandler)
-	adapter.router.HandleFunc("/", adapter.listHandler).Methods("GET")
-	adapter.router.HandleFunc("/", adapter.addHandler).Methods("POST")
+	adapter.router.PathPrefix("/{id}").HandlerFunc(adapter.userHandler)
+	adapter.router.Methods("GET").HandlerFunc(adapter.listHandler)
+	adapter.router.Methods("POST").HandlerFunc(adapter.addHandler)
 	return adapter
 }
 func (a *UsersServerAdapter) userHandler(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	target := a.server.User(id)
-	targetAdapter := NewUserServerAdapter(target, a.router.PathPrefix("/{id}/").Subrouter())
+	targetAdapter := NewUserServerAdapter(target, a.router.PathPrefix("/{id}").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }

--- a/clustersmgmt/v1/version_server.go
+++ b/clustersmgmt/v1/version_server.go
@@ -91,7 +91,7 @@ func NewVersionServerAdapter(server VersionServer, router *mux.Router) *VersionS
 	adapter := new(VersionServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.HandleFunc("/", adapter.getHandler).Methods("GET")
+	adapter.router.Methods("GET").HandlerFunc(adapter.getHandler)
 	return adapter
 }
 func (a *VersionServerAdapter) readVersionGetServerRequest(r *http.Request) (*VersionGetServerRequest, error) {

--- a/clustersmgmt/v1/versions_server.go
+++ b/clustersmgmt/v1/versions_server.go
@@ -269,14 +269,14 @@ func NewVersionsServerAdapter(server VersionsServer, router *mux.Router) *Versio
 	adapter := new(VersionsServerAdapter)
 	adapter.server = server
 	adapter.router = router
-	adapter.router.PathPrefix("/{id}/").HandlerFunc(adapter.versionHandler)
-	adapter.router.HandleFunc("/", adapter.listHandler).Methods("GET")
+	adapter.router.PathPrefix("/{id}").HandlerFunc(adapter.versionHandler)
+	adapter.router.Methods("GET").HandlerFunc(adapter.listHandler)
 	return adapter
 }
 func (a *VersionsServerAdapter) versionHandler(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	target := a.server.Version(id)
-	targetAdapter := NewVersionServerAdapter(target, a.router.PathPrefix("/{id}/").Subrouter())
+	targetAdapter := NewVersionServerAdapter(target, a.router.PathPrefix("/{id}").Subrouter())
 	targetAdapter.ServeHTTP(w, r)
 	return
 }


### PR DESCRIPTION
This patch updates the generated servers in the sdk so that they would be able to handle trailing slashes in routes. (e.g. `/versions`)

cc: @jhernand 